### PR TITLE
Fully initialize FSEventStreamContext

### DIFF
--- a/src/osx/RunLoop.cpp
+++ b/src/osx/RunLoop.cpp
@@ -64,9 +64,7 @@ void RunLoop::work() {
     1,
     NULL
   );
-  FSEventStreamContext callbackInfo;
-  callbackInfo.version = 0;
-  callbackInfo.info = (void *)mEventsService;
+  FSEventStreamContext callbackInfo {0, (void *)mEventsService, nullptr, nullptr, nullptr};
 
   mRunLoop = CFRunLoopGetCurrent();
   mEventStream = FSEventStreamCreate(


### PR DESCRIPTION
Recently we have been experimenting with nsfw on Atom, and we started experiencing hard crashes with stack traces similar to the following:

```
0   ???                           	0x0000000001010002 0 + 16842754
1   com.apple.CoreServices.FSEvents	0x00007fff99b74f59 _FSEventStreamCreate + 230
2   com.apple.CoreServices.FSEvents	0x00007fff99b74e6d FSEventStreamCreate + 107
3   nsfw.node                     	0x0000000111e71376 RunLoop::work() + 142 (RunLoop.cpp:72)
4   nsfw.node                     	0x0000000111e712e3 scheduleRunLoopWork(void*) + 9 (RunLoop.cpp:5)
5   libsystem_pthread.dylib       	0x00007fffadcc4aab _pthread_body + 180
6   libsystem_pthread.dylib       	0x00007fffadcc49f7 _pthread_start + 286
7   libsystem_pthread.dylib       	0x00007fffadcc4221 thread_start + 13
```

After debugging some of them, I have noticed that sometimes `callbackInfo.retain` was non-null, even if nsfw never set a pointer to a `retain` function. I believe this was due to `callbackInfo` not being fully initialized, thus containing garbage values in its fields. In turn, `FSEventStreamCreate` was trying to call a non-existing function and, as a result, segfaulted.

This pull request fixes it by fully initializing `callbackInfo`, filling only the fields that are necessary to make nsfw work (`version` and `info`) and initializing the other ones (`retain`, `release` and `copyDescription`) to `nullptr`.

/cc: @implausible 