### PR TITLE
Remove segfault-handler from testing and update testing suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 env:
   matrix:
-    - export NODE_VERSION="0.12" CC=clang CXX=clang++ npm_config_clang=1
-    - export NODE_VERSION="4.1" CC=clang CXX=clang++ npm_config_clang=1
-    - export NODE_VERSION="5.0" CC=clang CXX=clang++ npm_config_clang=1
+    - export NODE_VERSION="4" CC=clang CXX=clang++ npm_config_clang=1
+    - export NODE_VERSION="6" CC=clang CXX=clang++ npm_config_clang=1
+    - export NODE_VERSION="7" CC=clang CXX=clang++ npm_config_clang=1
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,9 @@
 environment:
   matrix:
     # Node.js
-    - nodejs_version: "0.12"
     - nodejs_version: "4"
-    - nodejs_version: "5"
+    - nodejs_version: "6"
+    - nodejs_version: "7"
 
 branches:
   only:

--- a/js/spec/index-spec.js
+++ b/js/spec/index-spec.js
@@ -4,8 +4,6 @@ const promisify = require('promisify-node');
 const fse = promisify(require('fs-extra'));
 const exec = promisify((command, options, callback) =>
   require('child_process').exec(command, options, callback));
-const segfaultHandler = require('segfault-handler');
-segfaultHandler.registerHandler();
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 120000;
 

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "babel-cli": "^6.5.1",
     "babel-preset-es2015": "^6.5.0",
     "eslint": "^2.2.0",
-    "jasmine-node": "^2.0.0",
-    "segfault-handler": "^1.0.0"
+    "jasmine-node": "^2.0.0"
   },
   "keywords": [
     "FileWatcher",


### PR DESCRIPTION
Segfault-handler is currently broken, unsure if we'll need to bring this back in. Was primarily just for catching errors that had occurred in the dev process via testing.