### PR TITLE
Periodic segfault on Windows when stopping a watcher

### DIFF
--- a/includes/win32/ReadLoopRunner.h
+++ b/includes/win32/ReadLoopRunner.h
@@ -24,6 +24,7 @@ public:
   void setError(std::string error);
   void setSharedPointer(std::shared_ptr<ReadLoopRunner> *pointer);
   void swap(DWORD numBytes);
+  void prepareForShutdown();
 
 private:
   unsigned int mBufferSize;

--- a/includes/win32/ReadLoopRunner.h
+++ b/includes/win32/ReadLoopRunner.h
@@ -19,7 +19,7 @@ public:
   std::string getUTF8Directory(std::wstring path);
   void handleEvents();
   bool hasErrored();
-  void read();
+  BOOL read();
   void resizeBuffers(unsigned int bufferSize);
   void setError(std::string error);
   void setSharedPointer(std::shared_ptr<ReadLoopRunner> *pointer);

--- a/js/spec/index-spec.js
+++ b/js/spec/index-spec.js
@@ -505,6 +505,25 @@ describe('Node Sentinel File Watcher', function() {
           watch.stop().then((err) => done.fail(err)));
     });
 
+    it('creates and destroys many watchers', function(done) {
+      let watcher = null;
+      let promiseChain = Promise.resolve();
+
+      for (let i = 0; i < 100; i++) {
+        promiseChain = promiseChain
+          .then(() => nsfw(stressRepoPath, () => {}))
+          .then(w => {
+            watcher = w;
+            return watcher.start();
+          })
+          .then(() => {
+            return watcher.stop();
+          });
+      }
+
+      promiseChain.then(done, err => done.fail(err));
+    });
+
     afterEach(function(done) {
       return fse.remove(stressRepoPath)
         .then(done);

--- a/src/win32/ReadLoop.cpp
+++ b/src/win32/ReadLoop.cpp
@@ -118,6 +118,7 @@ void CALLBACK ReadLoop::killReadLoop(__in ULONG_PTR arg) {
 
 void ReadLoop::shutdown() {
 	if (mRunner != NULL) {
+		mRunner->get()->prepareForShutdown();
 		delete mRunner;
 		mRunner = NULL;
 	}

--- a/src/win32/ReadLoopRunner.cpp
+++ b/src/win32/ReadLoopRunner.cpp
@@ -192,6 +192,10 @@ bool ReadLoopRunner::hasErrored() {
 BOOL ReadLoopRunner::read() {
   DWORD bytes;
 
+  if (mDirectoryHandle == NULL) {
+    return FALSE;
+  }
+
   if (!ReadDirectoryChangesW(
     mDirectoryHandle,
     mBuffer,
@@ -234,4 +238,8 @@ void ReadLoopRunner::setSharedPointer(std::shared_ptr<ReadLoopRunner> *ptr) {
 
 void ReadLoopRunner::swap(DWORD numBytes) {
   memcpy(mSwap, mBuffer, numBytes);
+}
+
+void ReadLoopRunner::prepareForShutdown() {
+  mDirectoryHandle = NULL;
 }


### PR DESCRIPTION
We've been seeing frequent segfaults in our AppVeyor Windows builds recently, and after some digging I believe the race condition that's addressed here is the culprit. Very occasionally, `ReadLoopRunner::eventCallback()` is invoked with `ERROR_SUCCESS` as its final call after `CancelIo` is issued, which results in a use-after-free error. Here's the sequence of events:

1. `ReadLoop::~ReadLoop()` is called to shut down a watcher.
2. The `ReadLoop` thread is awoken to run `ReadLoop::killReadLoop()`, which calls `ReadLoop::shutdown()`. `CancelIo` is called on the directory handle and it's closed. The `shared_ptr` containing the runner is deleted, but the runner isn't deallocated yet because the runner's `mOverlapped.hEvent` reference is still alive.
3. `ReadLoopRunner::eventCallback()` is triggered one final time. Ordinarily, its `errorCode` argument is `ERROR_OPERATION_ABORTED` _(995)_. Very occasionally, though, its `errorCode` is `ERROR_SUCCESS`. I haven't identified the situations that can trigger this reliably. Possibly it's when there are events waiting in the buffer when IO is cancelled?
3. `ReadLoopRunner::read()` is called to schedule the next asynchronous change notification... but `mDirectoryHandle` is now invalid. The `ReadDirectoryChangesW()` call fails with an "Invalid handle" error. The `shared_ptr` from `mOverlapped` is deleted again... and because the other reference was deleted before, the `ReadLoopRunner` is deallocated and its buffers are freed. The `read()` method returns regardless.
4. `ReadLoopRunner::handleEvents()` is called on the dead runner. On the first attempt to read from a data member -- the pointer dereferences `info->FileName` and `info->FileNameLength` --  the process segfaults. This is where the stack points if you load it up in WinDbg.

I've addressed this in two places:

* If a call to `ReadDirectoryChangesW()` fails, the deletion of the runner's `shared_ptr` is deferred to the _end_ of the `eventCallback()` call. This prevents the segfault by only allowing the runner to be deallocated after `handleEvents()` has enqueued the final events.
* When shutting a `ReadLoop` down, `NULL` out the directory handle reference within the runner before deleting the shared_ptr. If the directory handle is `NULL` in the call to `read()`, don't even attempt a `ReadDirectoryChangesW()` call. This prevents the failing `ReadDirectoryChangesW()` call.

I've also added a test that stresses the creation and deletion of a large number of watchers in an attempt to trigger this. I couldn't reproduce the crash on _every_ run but I'd see it pretty frequently with this in place.