### PR TITLE
Handle clean up / initialization better

### DIFF
--- a/includes/osx/RunLoop.h
+++ b/includes/osx/RunLoop.h
@@ -6,6 +6,7 @@
 
 #include <CoreServices/CoreServices.h>
 #include <pthread.h>
+#include <uv.h>
 #include <string>
 
 void *scheduleRunLoopWork(void *runLoop);
@@ -37,7 +38,7 @@ private:
   std::string mPath;
   CFRunLoopRef mRunLoop;
   pthread_t mRunLoopThread;
-  pthread_mutex_t mMutex;
+  uv_sem_t mReadyForCleanup;
   bool mStarted;
 };
 


### PR DESCRIPTION
 - We can perform fsevents clean up on the work thread
 - We should use pthread_join to sync the run loop exit
 - We should change the lock pattern to act as an initialization guard
   - This should eliminate the possibility that we have started the thread, but not the run loop, when we go to clean up in the destructor of RunLoop.

This will (hopefully) fix https://github.com/Axosoft/nsfw/issues/21.