### PR TITLE
Workaround for FreeBSD by using libinotify

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -25,7 +25,7 @@
                     "src/win32/ReadLoop.cpp",
                     "src/win32/ReadLoopRunner.cpp",
                     "includes/win32/ReadLoop.h",
-                    "includes/win32/ReadLoopRunner.h",
+                    "includes/win32/ReadLoopRunner.h"
                 ],
                 "msvs_settings": {
                     "VCCLCompilerTool": {
@@ -56,7 +56,7 @@
                     }
                 }
             }],
-            ["OS=='linux'", {
+            ["OS=='linux' or OS=='freebsd'", {
                 "sources": [
                     "src/Lock.cpp",
                     "src/linux/InotifyEventLoop.cpp",
@@ -81,24 +81,29 @@
                     ["target_arch=='x64'", {
                         "VCLibrarianTool": {
                           "AdditionalOptions": [
-                            "/MACHINE:X64",
-                          ],
-                        },
+                            "/MACHINE:X64"
+                          ]
+                        }
                     }, {
                         "VCLibrarianTool": {
                           "AdditionalOptions": [
-                            "/MACHINE:x86",
-                          ],
-                        },
-                    }],
+                            "/MACHINE:x86"
+                          ]
+                        }
+                    }]
                 ]
             }],
-            ["OS=='mac' or OS=='linux'", {
+            ["OS=='mac' or OS=='linux' or OS=='freebsd'", {
                 "defines": [
                     "OPA_HAVE_GCC_INTRINSIC_ATOMICS=1",
                     "HAVE_STDDEF_H=1",
                     "HAVE_STDLIB_H=1",
                     "HAVE_UNISTD_H=1"
+                ]
+            }],
+            ["OS=='freebsd'", {
+                "include_dirs": [
+                    "/usr/local/include"
                 ]
             }],
             ["target_arch=='x64' or target_arch=='arm64'", {
@@ -111,6 +116,6 @@
                     "OPA_SIZEOF_VOID_P=4"
                 ]
             }]
-        ],
+        ]
     }]
 }

--- a/openpa/openpa.gyp
+++ b/openpa/openpa.gyp
@@ -33,19 +33,19 @@
                         ["target_arch=='x64'", {
                             "VCLibrarianTool": {
                               "AdditionalOptions": [
-                                "/MACHINE:X64",
-                              ],
-                            },
+                                "/MACHINE:X64"
+                              ]
+                            }
                         }, {
                             "VCLibrarianTool": {
                               "AdditionalOptions": [
-                                "/MACHINE:x86",
-                              ],
-                            },
-                        }],
+                                "/MACHINE:x86"
+                              ]
+                            }
+                        }]
                     ]
                 }],
-                ["OS=='mac' or OS=='linux'", {
+                ["OS=='mac' or OS=='linux' or OS=='freebsd'", {
                     "sources": [
                         "src/primitives/opa_gcc_intrinsics.h"
                     ],

--- a/src/NativeInterface.cpp
+++ b/src/NativeInterface.cpp
@@ -3,10 +3,10 @@
 #if defined(_WIN32)
 #define SERVICE ReadLoop
 #include "../includes/win32/ReadLoop.h"
-#elif defined(__APPLE_CC__) || defined(BSD)
+#elif defined(__APPLE_CC__)
 #define SERVICE FSEventsService
 #include "../includes/osx/FSEventsService.h"
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__FreeBSD__)
 #define SERVICE InotifyService
 #include "../includes/linux/InotifyService.h"
 #endif


### PR DESCRIPTION
This PR is a workaround for FreeBSD to be able to use this module since currently there is no scalable file/directory watching on FreeBSD ([ref](https://en.wikipedia.org/wiki/Gamin#How_it_works)). `libinotify` just a wrapper on `kqueue` to provide `inotify` API.