### PR TITLE
Fix infinite loop setting up the inotify tree with recursive symbolic links on Linux

### DIFF
--- a/includes/linux/InotifyTree.h
+++ b/includes/linux/InotifyTree.h
@@ -9,6 +9,7 @@
 #include <sstream>
 #include <vector>
 #include <map>
+#include <unordered_set>
 
 class InotifyTree {
 public:
@@ -32,7 +33,8 @@ private:
       int inotifyInstance,
       InotifyNode *parent,
       std::string directory,
-      std::string name
+      std::string name,
+      ino_t inodeNumber
     );
 
     void addChild(std::string name);
@@ -61,6 +63,7 @@ private:
     std::map<std::string, InotifyNode *> *mChildren;
     std::string mDirectory;
     std::string mFullPath;
+    ino_t mInodeNumber;
     const int mInotifyInstance;
     std::string mName;
     InotifyNode *mParent;
@@ -72,10 +75,13 @@ private:
   void setError(std::string error);
   void addNodeReferenceByWD(int watchDescriptor, InotifyNode *node);
   void removeNodeReferenceByWD(int watchDescriptor);
+  bool addInode(ino_t inodeNumber);
+  void removeInode(ino_t inodeNumber);
 
   std::string mError;
   const int mInotifyInstance;
   std::map<int, InotifyNode *> *mInotifyNodeByWatchDescriptor;
+  std::unordered_set<ino_t> inodes;
   InotifyNode *mRoot;
 
   friend class InotifyNode;

--- a/js/spec/index-spec.js
+++ b/js/spec/index-spec.js
@@ -418,6 +418,18 @@ describe('Node Sentinel File Watcher', function() {
         .then(done, () =>
           watch.stop().then((err) => done.fail(err)));
     });
+
+    it('does not loop endlessly when watching directories with recursive symlinks', (done) => {
+      fse.mkdirSync(path.join(workDir, 'test'));
+      fse.symlinkSync(path.join(workDir, 'test'), path.join(workDir, 'test', 'link'));
+      return nsfw(
+        workDir,
+        () => {},
+        { debounceMS: DEBOUNCE, errorCallback() {} }
+      ).then((watch) => {
+        return watch.start();
+      }).then(done);
+    });
   });
 
   describe('Errors', function() {

--- a/src/linux/InotifyTree.cpp
+++ b/src/linux/InotifyTree.cpp
@@ -18,12 +18,20 @@ InotifyTree::InotifyTree(int inotifyInstance, std::string path):
     watchName = path.substr(location + 1);
   }
 
+  struct stat file;
+  if (stat((directory + "/" + watchName).c_str(), &file) < 0) {
+    mRoot = NULL;
+    return;
+  }
+
+  addInode(file.st_ino);
   mRoot = new InotifyNode(
     this,
     mInotifyInstance,
     NULL,
     directory,
-    watchName
+    watchName,
+    file.st_ino
   );
 
   if (
@@ -114,6 +122,14 @@ void InotifyTree::setError(std::string error) {
   mError = error;
 }
 
+bool InotifyTree::addInode(ino_t inodeNumber) {
+  return inodes.insert(inodeNumber).second;
+}
+
+void InotifyTree::removeInode(ino_t inodeNumber) {
+  inodes.erase(inodeNumber);
+}
+
 InotifyTree::~InotifyTree() {
   if (isRootAlive()) {
     delete mRoot;
@@ -128,9 +144,11 @@ InotifyTree::InotifyNode::InotifyNode(
   int inotifyInstance,
   InotifyNode *parent,
   std::string directory,
-  std::string name
+  std::string name,
+  ino_t inodeNumber
 ):
   mDirectory(directory),
+  mInodeNumber(inodeNumber),
   mInotifyInstance(inotifyInstance),
   mName(name),
   mParent(parent),
@@ -170,7 +188,8 @@ InotifyTree::InotifyNode::InotifyNode(
 
     if (
       stat(filePath.c_str(), &file) < 0 ||
-      !S_ISDIR(file.st_mode)
+      !S_ISDIR(file.st_mode) ||
+      !mTree->addInode(file.st_ino) // Skip this inode if already watching
     ) {
       continue;
     }
@@ -180,7 +199,8 @@ InotifyTree::InotifyNode::InotifyNode(
       mInotifyInstance,
       this,
       mFullPath,
-      fileName
+      fileName,
+      file.st_ino
     );
 
     if (child->isAlive()) {
@@ -198,6 +218,8 @@ InotifyTree::InotifyNode::InotifyNode(
 }
 
 InotifyTree::InotifyNode::~InotifyNode() {
+  mTree->removeInode(mInodeNumber);
+
   if (mWatchDescriptorInitialized) {
     inotify_rm_watch(mInotifyInstance, mWatchDescriptor);
     mTree->removeNodeReferenceByWD(mWatchDescriptor);
@@ -211,21 +233,26 @@ InotifyTree::InotifyNode::~InotifyNode() {
 }
 
 void InotifyTree::InotifyNode::addChild(std::string name) {
-  InotifyNode *child = new InotifyNode(
-    mTree,
-    mInotifyInstance,
-    this,
-    mFullPath,
-    name
-  );
+  struct stat file;
 
-  if (
-    child->isAlive() &&
-    child->inotifyInit()
-  ) {
-    (*mChildren)[name] = child;
-  } else {
-    delete child;
+  if (stat(createFullPath(mFullPath, name).c_str(), &file) >= 0 && mTree->addInode(file.st_ino)) {
+    InotifyNode *child = new InotifyNode(
+      mTree,
+      mInotifyInstance,
+      this,
+      mFullPath,
+      name,
+      file.st_ino
+    );
+
+    if (
+      child->isAlive() &&
+      child->inotifyInit()
+    ) {
+      (*mChildren)[name] = child;
+    } else {
+      delete child;
+    }
   }
 }
 


### PR DESCRIPTION
Previously, when constructing the `InotifyTree`, this library would unconditionally follow all symbolic links, even if they pointed to an ancestor of the current path. This would lead to infinite recursion building out a deeper and deeper tree until the process ran out of memory.

In this PR, we associate the tree with an `std::unordered_set` of inode numbers. These are already obtained in the common case of walking each directory's children via `stat` calls. We've had to add a couple more `stat` calls to get the inode of the root of the tree and of any newly added directories.

Now, when processing a directory's children, we only proceed if the inode number associated with the child has never been seen before.

We've added a basic new test with a simple recursive link where we just ensure the test does not time out. We've also run this under `valgrind` and haven't noticed any abnormal behavior associated with the newly added code.