### PR TITLE
docs: Indent options' children properly

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,8 +8,8 @@ const nsfw = require('nsfw');
  - **watchPath**: the path that nsfw should watchPath
  - **eventCallback**: callback that will be fired when NSFW has change events
  - **options**
-  - **debounceMS**: time in milliseconds to debounce the event callback
-  - **errorCallback**: callback to fire in the case of errors
+   - **debounceMS**: time in milliseconds to debounce the event callback
+   - **errorCallback**: callback to fire in the case of errors
 
 
   Returns a Promise that resolves to the created NSFW Object.


### PR DESCRIPTION
The children of `options` are indented with only one space.  In the rendered Markdown (at least on Github), they appear at the same level as `options` itself, which makes it unclear that they are members of `options`.  Indent them with two spaces so they also appear indented in the rendered Markdown.