### PR TITLE
Fix node 10 compilation error

### DIFF
--- a/src/NSFW.cpp
+++ b/src/NSFW.cpp
@@ -155,8 +155,12 @@ NAN_MODULE_INIT(NSFW::Init) {
 
 NAN_METHOD(NSFW::JSNew) {
   if (!info.IsConstructCall()) {
-    v8::Local<v8::Function> cons = New<v8::Function>(constructor);
-    info.GetReturnValue().Set(cons->NewInstance());
+    const int argc = 4;
+    v8::Isolate *isolate = info.GetIsolate();
+    v8::Local<v8::Value> argv[argc] = {info[0], info[1], info[2], info[3]};
+    v8::Local<v8::Context> context = isolate->GetCurrentContext();
+    v8::Local<v8::Function> cons = v8::Local<v8::Function>::New(isolate, constructor);
+    info.GetReturnValue().Set(cons->NewInstance(context, argc, argv).ToLocalChecked());
     return;
   }
 


### PR DESCRIPTION
This fixes #52 and allows for the project to be compiled with node 10.

I've used the pattern presented in https://nodejs.org/api/addons.html#addons_wrapping_c_objects i.e.

```cpp
void MyObject::New(const FunctionCallbackInfo<Value>& args) {
  Isolate* isolate = args.GetIsolate();

  if (args.IsConstructCall()) {
    // Invoked as constructor: `new MyObject(...)`
    double value = args[0]->IsUndefined() ? 0 : args[0]->NumberValue();
    MyObject* obj = new MyObject(value);
    obj->Wrap(args.This());
    args.GetReturnValue().Set(args.This());
  } else {
    // Invoked as plain function `MyObject(...)`, turn into construct call.
    const int argc = 1;
    Local<Value> argv[argc] = { args[0] };
    Local<Context> context = isolate->GetCurrentContext();
    Local<Function> cons = Local<Function>::New(isolate, constructor);
    Local<Object> result =
        cons->NewInstance(context, argc, argv).ToLocalChecked();
    args.GetReturnValue().Set(result);
  }
}
```