### PR TITLE
Fix rename directory segfault on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ An array of events as they have happened in a directory, it's children, or to a 
     "action": 3, // nsfw.actions.RENAMED
     "directory": "home/nsfw/watchDir",
     "oldFile": "oldname.ext",
+    "newDirectory": "home/nsfw/watchDir/otherDirectory"
     "newFile": "newname.ext"
   }
 ]

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ const nsfw = require('nsfw');
   - **directory**: the location the event took place
   - **file**: the name of the file that was changed _(Not available for rename events)_
   - **oldFile**: the name of the file before a rename _(Only available for rename events)_
+  - **newDirectory**: the new location of the file _(Only available for rename events, only useful on linux)_
   - **newFile**: the name of the file after a rename _(Only available for rename events)_
 
 

--- a/includes/Queue.h
+++ b/includes/Queue.h
@@ -15,10 +15,22 @@ enum EventType {
 };
 
 struct Event {
-  Event(const EventType type, const std::string &directory, const std::string &fileA, const std::string &fileB) :
-      type(type), directory(directory), fileA(fileA), fileB(fileB) {}
+  Event(
+    const EventType type,
+    const std::string &fromDirectory,
+    const std::string &fromFile,
+    const std::string &toDirectory,
+    const std::string &toFile
+  ) :
+    type(type),
+    fromDirectory(fromDirectory),
+    toDirectory(toDirectory),
+    fromFile(fromFile),
+    toFile(toFile)
+  {}
+
   EventType type;
-  std::string directory, fileA, fileB;
+  std::string fromDirectory, toDirectory, fromFile, toFile;
 };
 
 class EventQueue {
@@ -28,10 +40,11 @@ public:
   std::unique_ptr<Event> dequeue();
   std::unique_ptr<std::vector<Event*>> dequeueAll();
   void enqueue(
-    EventType type,
-    const std::string &directory,
-    const std::string &fileA,
-    const std::string &fileB = ""
+    const EventType type,
+    const std::string &fromDirectory,
+    const std::string &fromFile,
+    const std::string &toDirectory = "",
+    const std::string &toFile = ""
   );
 
 private:

--- a/includes/linux/InotifyEventLoop.h
+++ b/includes/linux/InotifyEventLoop.h
@@ -33,7 +33,7 @@ private:
   struct InotifyRenameEvent {
     uint32_t cookie;
     bool isDirectory;
-    bool isGood;
+    bool isStarted;
     std::string name;
     int wd;
   };

--- a/includes/linux/InotifyService.h
+++ b/includes/linux/InotifyService.h
@@ -24,12 +24,12 @@ private:
   void createDirectory(int wd, std::string name);
   void createDirectoryTree(std::string directoryTreePath);
   void dispatch(EventType action, int wd, std::string name);
-  void dispatchRename(int wd, std::string oldName, std::string newName);
+  void dispatchRename(int fromWd, std::string fromName, int toWd, std::string toName);
   void modify(int wd, std::string name);
   void remove(int wd, std::string name);
   void removeDirectory(int wd);
-  void rename(int wd, std::string oldName, std::string newName);
-  void renameDirectory(int wd, std::string oldName, std::string newName);
+  void rename(int fromWd, std::string fromName, int toWd, std::string toName);
+  void renameDirectory(int fromWd, std::string fromName, int toWd, std::string toName);
 
   InotifyEventLoop *mEventLoop;
   std::shared_ptr<EventQueue> mQueue;

--- a/includes/linux/InotifyTree.h
+++ b/includes/linux/InotifyTree.h
@@ -22,7 +22,7 @@ public:
   bool isRootAlive();
   bool nodeExists(int wd);
   void removeDirectory(int wd);
-  void renameDirectory(int wd, std::string oldName, std::string newName);
+  void renameDirectory(int fromWd, std::string fromName, int toWd, std::string toName);
 
   ~InotifyTree();
 private:
@@ -44,9 +44,12 @@ private:
     InotifyNode *getParent();
     bool inotifyInit();
     bool isAlive();
+    InotifyNode *pullChild(std::string name);
     void removeChild(std::string name);
     void renameChild(std::string oldName, std::string newName);
     void setName(std::string name);
+    void setParent(InotifyNode *newParent);
+    void takeChildAsName(InotifyNode *child, std::string name);
 
     ~InotifyNode();
   private:

--- a/src/NSFW.cpp
+++ b/src/NSFW.cpp
@@ -73,13 +73,14 @@ void NSFW::fireEventCallback(uv_async_t *handle) {
     v8::Local<v8::Object> anEvent = New<v8::Object>();
 
     anEvent->Set(New<v8::String>("action").ToLocalChecked(), New<v8::Number>((*i)->type));
-    anEvent->Set(New<v8::String>("directory").ToLocalChecked(), New<v8::String>((*i)->directory).ToLocalChecked());
+    anEvent->Set(New<v8::String>("directory").ToLocalChecked(), New<v8::String>((*i)->fromDirectory).ToLocalChecked());
 
     if ((*i)->type == RENAMED) {
-      anEvent->Set(New<v8::String>("oldFile").ToLocalChecked(), New<v8::String>((*i)->fileA).ToLocalChecked());
-      anEvent->Set(New<v8::String>("newFile").ToLocalChecked(), New<v8::String>((*i)->fileB).ToLocalChecked());
+      anEvent->Set(New<v8::String>("oldFile").ToLocalChecked(), New<v8::String>((*i)->fromFile).ToLocalChecked());
+      anEvent->Set(New<v8::String>("newDirectory").ToLocalChecked(), New<v8::String>((*i)->toDirectory).ToLocalChecked());
+      anEvent->Set(New<v8::String>("newFile").ToLocalChecked(), New<v8::String>((*i)->toFile).ToLocalChecked());
     } else {
-      anEvent->Set(New<v8::String>("file").ToLocalChecked(), New<v8::String>((*i)->fileA).ToLocalChecked());
+      anEvent->Set(New<v8::String>("file").ToLocalChecked(), New<v8::String>((*i)->fromFile).ToLocalChecked());
     }
 
     jsEventObjects->push_back(anEvent);

--- a/src/Queue.cpp
+++ b/src/Queue.cpp
@@ -43,7 +43,13 @@ std::unique_ptr<std::vector<Event*>> EventQueue::dequeueAll() {
   return events;
 }
 
-void EventQueue::enqueue(const EventType type, const std::string &directory, const std::string &fileA, const std::string &fileB) {
+void EventQueue::enqueue(
+  const EventType type,
+  const std::string &fromDirectory,
+  const std::string &fromFile,
+  const std::string &toDirectory,
+  const std::string &toFile
+) {
   std::lock_guard<std::mutex> lock(mutex);
-  queue.emplace_back(std::unique_ptr<Event>(new Event(type, directory, fileA, fileB)));
+  queue.emplace_back(std::unique_ptr<Event>(new Event(type, fromDirectory, fromFile, toDirectory, toFile)));
 }

--- a/src/linux/InotifyEventLoop.cpp
+++ b/src/linux/InotifyEventLoop.cpp
@@ -87,9 +87,9 @@ void InotifyEventLoop::work() {
       create();
     } else {
       if (renameEvent.isDirectory) {
-        inotifyService->renameDirectory(renameEvent.wd, renameEvent.name, event->name);
+        inotifyService->renameDirectory(renameEvent.wd, renameEvent.name, event->wd, event->name);
       } else {
-        inotifyService->rename(renameEvent.wd, renameEvent.name, event->name);
+        inotifyService->rename(renameEvent.wd, renameEvent.name, event->wd, event->name);
       }
     }
     renameEvent.isGood = false;

--- a/src/linux/InotifyEventLoop.cpp
+++ b/src/linux/InotifyEventLoop.cpp
@@ -30,7 +30,7 @@ void InotifyEventLoop::work() {
   bool isDirectoryEvent = false, isDirectoryRemoval = false;
   InotifyService *inotifyService = mInotifyService;
   InotifyRenameEvent renameEvent;
-  renameEvent.isGood = false;
+  renameEvent.isStarted = false;
 
   auto create = [&event, &isDirectoryEvent, &inotifyService]() {
     if (event == NULL) {
@@ -69,11 +69,11 @@ void InotifyEventLoop::work() {
     renameEvent.isDirectory = isDirectoryEvent;
     renameEvent.name = event->name;
     renameEvent.wd = event->wd;
-    renameEvent.isGood = true;
+    renameEvent.isStarted = true;
   };
 
   auto renameEnd = [&create, &event, &inotifyService, &isDirectoryEvent, &renameEvent]() {
-    if (!renameEvent.isGood) {
+    if (!renameEvent.isStarted) {
       create();
       return;
     }
@@ -92,7 +92,7 @@ void InotifyEventLoop::work() {
         inotifyService->rename(renameEvent.wd, renameEvent.name, event->wd, event->name);
       }
     }
-    renameEvent.isGood = false;
+    renameEvent.isStarted = false;
   };
 
   mLoopingSemaphore.signal();
@@ -101,7 +101,7 @@ void InotifyEventLoop::work() {
     do {
       event = (struct inotify_event *)(buffer + position);
 
-      if (renameEvent.isGood && event->cookie != renameEvent.cookie) {
+      if (renameEvent.isStarted && event->cookie != renameEvent.cookie) {
         renameEnd();
       }
 
@@ -137,6 +137,10 @@ void InotifyEventLoop::work() {
         inotifyService->removeDirectory(event->wd);
       }
     } while((position += sizeof(struct inotify_event) + event->len) < bytesRead);
+    if (renameEvent.isStarted) {
+      remove();
+      renameEvent.isStarted = false;
+    }
     position = 0;
   }
   mStarted = false;

--- a/src/linux/InotifyService.cpp
+++ b/src/linux/InotifyService.cpp
@@ -48,13 +48,13 @@ void InotifyService::dispatch(EventType action, int wd, std::string name) {
   mQueue->enqueue(action, path, name);
 }
 
-void InotifyService::dispatchRename(int wd, std::string oldName, std::string newName) {
-  std::string path;
-  if (!mTree->getPath(path, wd)) {
+void InotifyService::dispatchRename(int fromWd, std::string fromName, int toWd, std::string toName) {
+  std::string fromPath, toPath;
+  if (!mTree->getPath(fromPath, fromWd) || !mTree->getPath(toPath, toWd)) {
     return;
   }
 
-  mQueue->enqueue(RENAMED, path, oldName, newName);
+  mQueue->enqueue(RENAMED, fromPath, fromName, toPath, toName);
 }
 
 std::string InotifyService::getError() {
@@ -89,8 +89,8 @@ void InotifyService::remove(int wd, std::string name) {
   dispatch(DELETED, wd, name);
 }
 
-void InotifyService::rename(int wd, std::string oldName, std::string newName) {
-  dispatchRename(wd, oldName, newName);
+void InotifyService::rename(int fromWd, std::string fromName, int toWd, std::string toName) {
+  dispatchRename(fromWd, fromName, toWd, toName);
 }
 
 void InotifyService::createDirectory(int wd, std::string name) {
@@ -106,12 +106,12 @@ void InotifyService::removeDirectory(int wd) {
   mTree->removeDirectory(wd);
 }
 
-void InotifyService::renameDirectory(int wd, std::string oldName, std::string newName) {
-  if (!mTree->nodeExists(wd)) {
+void InotifyService::renameDirectory(int fromWd, std::string fromName, int toWd, std::string toName) {
+  if (!mTree->nodeExists(fromWd) || !mTree->nodeExists(toWd)) {
     return;
   }
 
-  mTree->renameDirectory(wd, oldName, newName);
+  mTree->renameDirectory(fromWd, fromName, toWd, toName);
 
-  dispatchRename(wd, oldName, newName);
+  dispatchRename(fromWd, fromName, toWd, toName);
 }

--- a/src/linux/InotifyTree.cpp
+++ b/src/linux/InotifyTree.cpp
@@ -109,13 +109,29 @@ void InotifyTree::removeNodeReferenceByWD(int wd) {
   }
 }
 
-void InotifyTree::renameDirectory(int wd, std::string oldName, std::string newName) {
-  auto nodeIterator = mInotifyNodeByWatchDescriptor->find(wd);
-  if (nodeIterator == mInotifyNodeByWatchDescriptor->end()) {
+void InotifyTree::renameDirectory(int fromWd, std::string fromName, int toWd, std::string toName) {
+  auto fromNodeIterator = mInotifyNodeByWatchDescriptor->find(fromWd);
+  if (fromNodeIterator == mInotifyNodeByWatchDescriptor->end()) {
     return;
   }
 
-  nodeIterator->second->renameChild(oldName, newName);
+  if (fromWd == toWd) {
+    fromNodeIterator->second->renameChild(fromName, toName);
+    return;
+  }
+
+  auto toNodeIterator = mInotifyNodeByWatchDescriptor->find(toWd);
+  if (toNodeIterator == mInotifyNodeByWatchDescriptor->end()) {
+    return;
+  }
+
+  InotifyNode *pulledChild = fromNodeIterator->second->pullChild(fromName);
+
+  if (!pulledChild) {
+    return;
+  }
+
+  toNodeIterator->second->takeChildAsName(pulledChild, toName);
 }
 
 void InotifyTree::setError(std::string error) {
@@ -379,6 +395,10 @@ void InotifyTree::InotifyNode::setName(std::string name) {
   fixPaths();
 }
 
+void InotifyTree::InotifyNode::setParent(InotifyNode *newParent) {
+  mParent = newParent;
+}
+
 std::string InotifyTree::InotifyNode::createFullPath(std::string parentPath, std::string name) {
   std::stringstream fullPathStream;
 
@@ -388,4 +408,22 @@ std::string InotifyTree::InotifyNode::createFullPath(std::string parentPath, std
     << name;
 
   return fullPathStream.str();
+}
+
+InotifyTree::InotifyNode *InotifyTree::InotifyNode::pullChild(std::string name) {
+  auto child = mChildren->find(name);
+  if (child == mChildren->end()) {
+    return NULL;
+  }
+
+  auto node = child->second;
+  node->setParent(NULL);
+  mChildren->erase(child);
+  return node;
+}
+
+void InotifyTree::InotifyNode::takeChildAsName(InotifyNode *child, std::string name) {
+  (*mChildren)[name] = child;
+  child->setParent(this);
+  child->setName(name);
 }

--- a/src/osx/FSEventsService.cpp
+++ b/src/osx/FSEventsService.cpp
@@ -125,9 +125,9 @@ void FSEventsService::rename(std::vector<std::string> *paths) {
            sideBExists = stat(fullSideB.c_str(), &renameSideB) == 0;
 
       if (sideAExists && !sideBExists) {
-        mQueue->enqueue(RENAMED, binIterator->first, sideB, sideA);
+        mQueue->enqueue(RENAMED, binIterator->first, sideB, binIterator->first, sideA);
       } else if (!sideAExists && sideBExists) {
-        mQueue->enqueue(RENAMED, binIterator->first, sideA, sideB);
+        mQueue->enqueue(RENAMED, binIterator->first, sideA, binIterator->first, sideB);
       } else {
         demangle(fullSideA);
         demangle(fullSideB);

--- a/src/win32/Watcher.cpp
+++ b/src/win32/Watcher.cpp
@@ -189,6 +189,7 @@ void Watcher::handleEvents() {
             RENAMED,
             getUTF8Directory(fileName),
             getUTF8FileName(fileName),
+            getUTF8Directory(fileName),
             getUTF8FileName(fileNameNew)
           );
         } else {


### PR DESCRIPTION
It looks like a move event can occur cross directories so long as we have a watch established in each location. This causes some strange linking behavior of the tree in linux land.

The pattern to cause the segfault is to have a directory structure like:
```
/
--a/
----b/
----c/
--d/
```
1. Move `a/b/` to `d/b/`.
2. Move `a/c/` to `a/b/`.
3. Delete `a`.
4. Delete `d`.

For some reason, this does not occur 100% of the time, though it was fairly deterministic on my home computer when running in GitKraken. The only way to get it to repro in node 6 and 8 was to cause several events that perform the same procedure. And for some reason node 10 seems resilient to the issue.

The proposed fix would be to improve the rename event in linux to support cross watched directory moves, and to include the new directory path with it. This will add an extra field `newDirectory` to the rename event. This would be backwards compatible with what we're currently reporting, but would also yield better rename details in linux.