### PR TITLE
Patch memory leaks in fireEventCallback

### DIFF
--- a/includes/NSFW.h
+++ b/includes/NSFW.h
@@ -41,7 +41,7 @@ private:
 
   struct EventBaton {
     NSFW *nsfw;
-    std::vector<Event*> *events;
+    std::unique_ptr<std::vector<std::unique_ptr<Event>>> events;
   };
 
   static NAN_METHOD(JSNew);

--- a/includes/NativeInterface.h
+++ b/includes/NativeInterface.h
@@ -21,7 +21,7 @@ public:
   ~NativeInterface();
 
   std::string getError();
-  std::vector<Event*> *getEvents();
+  std::unique_ptr<std::vector<std::unique_ptr<Event>>> getEvents();
   bool hasErrored();
   bool isWatching();
 

--- a/includes/Queue.h
+++ b/includes/Queue.h
@@ -38,7 +38,7 @@ public:
   void clear();
   std::size_t count();
   std::unique_ptr<Event> dequeue();
-  std::unique_ptr<std::vector<Event*>> dequeueAll();
+  std::unique_ptr<std::vector<std::unique_ptr<Event>>> dequeueAll();
   void enqueue(
     const EventType type,
     const std::string &fromDirectory,

--- a/src/NSFW.cpp
+++ b/src/NSFW.cpp
@@ -58,6 +58,11 @@ void NSFW::fireEventCallback(uv_async_t *handle) {
   if (baton->events->empty()) {
     uv_thread_t cleanup;
     uv_thread_create(&cleanup, NSFW::cleanupEventCallback, baton);
+
+    #if defined(__APPLE_CC__) ||  defined(__linux__) || defined(__FreeBSD__)
+    pthread_detach(cleanup);
+    #endif
+
     return;
   }
 
@@ -89,6 +94,10 @@ void NSFW::fireEventCallback(uv_async_t *handle) {
 
   uv_thread_t cleanup;
   uv_thread_create(&cleanup, NSFW::cleanupEventCallback, baton);
+
+  #if defined(__APPLE_CC__) ||  defined(__linux__) || defined(__FreeBSD__)
+  pthread_detach(cleanup);
+  #endif
 }
 
 void NSFW::pollForEvents(void *arg) {

--- a/src/NativeInterface.cpp
+++ b/src/NativeInterface.cpp
@@ -13,8 +13,8 @@ std::string NativeInterface::getError() {
   return mNativeInterface->getError();
 }
 
-std::vector<Event*> *NativeInterface::getEvents() {
-  return mQueue->dequeueAll().release();
+std::unique_ptr<std::vector<std::unique_ptr<Event>>> NativeInterface::getEvents() {
+  return mQueue->dequeueAll();
 }
 
 bool NativeInterface::hasErrored() {

--- a/src/Queue.cpp
+++ b/src/Queue.cpp
@@ -26,17 +26,17 @@ std::unique_ptr<Event> EventQueue::dequeue() {
   return retVal;
 }
 
-std::unique_ptr<std::vector<Event*>> EventQueue::dequeueAll() {
+std::unique_ptr<std::vector<std::unique_ptr<Event>>> EventQueue::dequeueAll() {
   std::lock_guard<std::mutex> lock(mutex);
   if (queue.empty()) {
     return nullptr;
   }
 
   const auto queueSize = queue.size();
-  std::unique_ptr<std::vector<Event*>> events(new std::vector<Event*>(queueSize, nullptr));
+  std::unique_ptr<std::vector<std::unique_ptr<Event>>> events(new std::vector<std::unique_ptr<Event>>);
   for (size_t i = 0; i < queueSize; ++i) {
     auto &front = queue.front();
-    (*events)[i] = front.release();
+    events->emplace_back(std::move(front));
     queue.pop_front();
   }
 

--- a/src/linux/InotifyTree.cpp
+++ b/src/linux/InotifyTree.cpp
@@ -227,10 +227,10 @@ InotifyTree::InotifyNode::InotifyNode(
   }
 
   for (int i = 0; i < resultCountOrError; ++i) {
-    delete directoryContents[i];
+    free(directoryContents[i]);
   }
 
-  delete[] directoryContents;
+  free(directoryContents);
 }
 
 InotifyTree::InotifyNode::~InotifyNode() {

--- a/src/linux/InotifyTree.cpp
+++ b/src/linux/InotifyTree.cpp
@@ -150,6 +150,7 @@ InotifyTree::~InotifyTree() {
   if (isRootAlive()) {
     delete mRoot;
   }
+  delete mInotifyNodeByWatchDescriptor;
 }
 
 /**


### PR DESCRIPTION
It seems we are leaking thread data here. We will need to call pthread_detach on our cleanup thread routines to ensure that they cleanup their thread state after they perform their duties.

Closes https://github.com/Axosoft/nsfw/issues/48