### PR TITLE
Fix module loading in Electron 4

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -10,7 +10,6 @@
             "includes/Queue.h",
             "includes/NativeInterface.h"
         ],
-        "win_delay_load_hook": "false",
         "include_dirs": [
             "<!(node -e \"require('nan')\")",
             "includes"


### PR DESCRIPTION
Fixes #68. See: https://electronjs.org/docs/tutorial/using-native-node-modules#a-note-about-win_delay_load_hook