### PR TITLE
Fix memory leaks

### DIFF
--- a/src/linux/InotifyEventLoop.cpp
+++ b/src/linux/InotifyEventLoop.cpp
@@ -38,9 +38,9 @@ void InotifyEventLoop::work() {
     }
 
     if (isDirectoryEvent) {
-      inotifyService->createDirectory(event->wd, strdup(event->name));
+      inotifyService->createDirectory(event->wd, event->name);
     } else {
-      inotifyService->create(event->wd, strdup(event->name));
+      inotifyService->create(event->wd, event->name);
     }
   };
 
@@ -49,7 +49,7 @@ void InotifyEventLoop::work() {
       return;
     }
 
-    inotifyService->modify(event->wd, strdup(event->name));
+    inotifyService->modify(event->wd, event->name);
   };
 
   auto remove = [&event, &isDirectoryRemoval, &inotifyService]() {
@@ -60,7 +60,7 @@ void InotifyEventLoop::work() {
     if (isDirectoryRemoval) {
       inotifyService->removeDirectory(event->wd);
     } else {
-      inotifyService->remove(event->wd, strdup(event->name));
+      inotifyService->remove(event->wd, event->name);
     }
   };
 
@@ -133,7 +133,7 @@ void InotifyEventLoop::work() {
 
         renameStart();
       } else if (event->mask & (uint32_t)IN_MOVE_SELF) {
-        inotifyService->remove(event->wd, strdup(event->name));
+        inotifyService->remove(event->wd, event->name);
         inotifyService->removeDirectory(event->wd);
       }
     } while((position += sizeof(struct inotify_event) + event->len) < bytesRead);


### PR DESCRIPTION
Here are the two memory leaks I currently found in this repository: 
 - **Unneeded `strdup()` in [src/linux/InotifyEventLoop.cpp](https://github.com/Axosoft/nsfw/blob/master/src/linux/InotifyEventLoop.cpp)**
     - This is easy to fix. Just to remove strdup function call and just pass a C-string; C++ string will make a copy by itself.
 - **Not every call to `uv_async_send()` will yield an execution of the callback** ([Document](http://docs.libuv.org/en/v1.x/async.html#c.uv_async_send)). 
     -  `mEventCallbackAsync` may not be called. As a result, `EventBaton` and its events won't be freed by `cleanupEventCallback()`
     - This bug is not easy to fix, since it may need to change the method to pass events in order to fix it.

This pull request currently fixed the first leaks. 
Related to #72 