### PR TITLE
Make event queue shared between nsfw and native implementation

### DIFF
--- a/includes/NativeInterface.h
+++ b/includes/NativeInterface.h
@@ -17,16 +17,14 @@ using NativeImplementation = InotifyService;
 
 class NativeInterface {
 public:
-  NativeInterface(const std::string &path);
+  NativeInterface(const std::string &path, std::shared_ptr<EventQueue> queue);
   ~NativeInterface();
 
   std::string getError();
-  std::unique_ptr<std::vector<std::unique_ptr<Event>>> getEvents();
   bool hasErrored();
   bool isWatching();
 
 private:
-  std::shared_ptr<EventQueue> mQueue;
   std::unique_ptr<NativeImplementation> mNativeInterface;
 };
 

--- a/js/spec/index-spec.js
+++ b/js/spec/index-spec.js
@@ -2,11 +2,14 @@ const nsfw = require('../src/');
 const path = require('path');
 const fse = require('fs-extra');
 const exec = require('executive');
+const { promisify } = require('util');
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 120000;
 
 const DEBOUNCE = 1000;
 const TIMEOUT_PER_STEP = 3000;
+
+const timeout = promisify(setTimeout);
 
 describe('Node Sentinel File Watcher', function() {
   const workDir = path.resolve('./mockfs');
@@ -396,7 +399,9 @@ describe('Node Sentinel File Watcher', function() {
           return paths.reduce((chain, dir) => {
             directory = path.join(directory, dir);
             const nextDirectory = directory;
-            return chain.then(() => fse.mkdir(nextDirectory));
+            return chain
+              .then(() => fse.mkdir(nextDirectory))
+              .then(() => timeout(60));
           }, Promise.resolve());
         })
         .then(() => fse.open(path.join(directory, file), 'w'))

--- a/src/NativeInterface.cpp
+++ b/src/NativeInterface.cpp
@@ -1,8 +1,7 @@
 #include "../includes/NativeInterface.h"
 
-NativeInterface::NativeInterface(const std::string &path) {
-  mQueue = std::make_shared<EventQueue>();
-  mNativeInterface.reset(new NativeImplementation(mQueue, path));
+NativeInterface::NativeInterface(const std::string &path, std::shared_ptr<EventQueue> queue) {
+  mNativeInterface.reset(new NativeImplementation(queue, path));
 }
 
 NativeInterface::~NativeInterface() {
@@ -11,10 +10,6 @@ NativeInterface::~NativeInterface() {
 
 std::string NativeInterface::getError() {
   return mNativeInterface->getError();
-}
-
-std::unique_ptr<std::vector<std::unique_ptr<Event>>> NativeInterface::getEvents() {
-  return mQueue->dequeueAll();
 }
 
 bool NativeInterface::hasErrored() {


### PR DESCRIPTION
Don't create an EventBaton which can be leaked according to the documentation in uv_async_send.
This solves the second issue mentioned in https://github.com/Axosoft/nsfw/pull/74.