### PR TITLE
Fixed file renaming on Windows

### DIFF
--- a/js/spec/index-spec.js
+++ b/js/spec/index-spec.js
@@ -254,10 +254,9 @@ describe('Node Sentinel File Watcher', function() {
       const waitTimeout = () => new Promise(resolve => {
         setTimeout(resolve, TIMEOUT_PER_STEP);
       });
-      const srcFile = 'testing0.file';
-      const destFile = 'testing1.file';
-      const srcInPath = path.resolve(workDir, 'test4', 'srcfolder');
-      const destInPath = path.resolve(workDir, 'test4', 'destfolder');
+      const srcFile = 'testing.file';
+      const destFile = 'new-testing.file';
+      const inPath = path.resolve(workDir, 'test4');
       let eventListening = false;
       let eventFound = false;
       let extraEventFound = false;
@@ -268,14 +267,16 @@ describe('Node Sentinel File Watcher', function() {
         }
         if (
           element.action === nsfw.actions.RENAMED &&
-          element.directory === path.resolve(srcInPath) &&
+          element.directory === path.resolve(inPath) &&
           element.oldFile === srcFile &&
-          element.newDirectory === path.resolve(destInPath) &&
+          element.newDirectory === path.resolve(inPath) &&
           element.newFile === destFile
         ) {
           eventFound = true;
         } else {
-          extraEventFound = true;
+          if (element.directory === path.resolve(inPath)) {
+            extraEventFound = true;
+          }
         }
       }
 
@@ -292,13 +293,12 @@ describe('Node Sentinel File Watcher', function() {
         })
         .then(waitTimeout)
         .then(() => {
-          fse.ensureFileSync(path.join(srcInPath, srcFile));
-          fse.ensureDirSync(destInPath);
+          fse.ensureFileSync(path.join(inPath, srcFile));
         })
         .then(waitTimeout)
         .then(() => {
           eventListening = true;
-          return fse.move(path.join(srcInPath, srcFile), path.join(destInPath, destFile));
+          return fse.move(path.join(inPath, srcFile), path.join(inPath, destFile));
         })
         .then(waitTimeout)
         .then(() => {

--- a/js/spec/index-spec.js
+++ b/js/spec/index-spec.js
@@ -250,6 +250,70 @@ describe('Node Sentinel File Watcher', function() {
           watch.stop().then((err) => done.fail(err)));
     });
 
+    it('can listen for a rename event', function(done) {
+      const waitTimeout = () => new Promise(resolve => {
+        setTimeout(resolve, TIMEOUT_PER_STEP);
+      });
+      const srcFile = 'testing0.file';
+      const destFile = 'testing1.file';
+      const srcInPath = path.resolve(workDir, 'test4', 'srcfolder');
+      const destInPath = path.resolve(workDir, 'test4', 'destfolder');
+      let eventListening = false;
+      let eventFound = false;
+      let extraEventFound = false;
+
+      function findEvent(element) {
+        if (!eventListening) {
+          return;
+        }
+        if (
+          element.action === nsfw.actions.RENAMED &&
+          element.directory === path.resolve(srcInPath) &&
+          element.oldFile === srcFile &&
+          element.newDirectory === path.resolve(destInPath) &&
+          element.newFile === destFile
+        ) {
+          eventFound = true;
+        } else {
+          extraEventFound = true;
+        }
+      }
+
+      let watch;
+
+      return nsfw(
+        workDir,
+        events => events.forEach(findEvent),
+        { debounceMS: DEBOUNCE }
+      )
+        .then(_w => {
+          watch = _w;
+          return watch.start();
+        })
+        .then(waitTimeout)
+        .then(() => {
+          fse.ensureFileSync(path.join(srcInPath, srcFile));
+          fse.ensureDirSync(destInPath);
+        })
+        .then(waitTimeout)
+        .then(() => {
+          eventListening = true;
+          return fse.move(path.join(srcInPath, srcFile), path.join(destInPath, destFile));
+        })
+        .then(waitTimeout)
+        .then(() => {
+          eventListening = false;
+        })
+        .then(() => {
+          expect(eventFound).toBe(true);
+          expect(extraEventFound).toBe(false);
+          return watch.stop();
+        })
+        .then(done, () => {
+          watch.stop().then((err) => done.fail(err));
+        });
+    });
+
     it('can run multiple watchers at once', function(done) {
       const dirA = path.resolve(workDir, 'test0');
       const fileA = 'testing1.file';

--- a/js/spec/index-spec.js
+++ b/js/spec/index-spec.js
@@ -13,6 +13,9 @@ const timeout = promisify(setTimeout);
 
 describe('Node Sentinel File Watcher', function() {
   const workDir = path.resolve('./mockfs');
+  const isWin = process.platform === 'win32';
+  const isLinux = process.platform === 'linux';
+  const isOsx = process.platform === 'darwin';
 
   beforeEach(function(done) {
     function makeDir(identifier) {
@@ -306,6 +309,92 @@ describe('Node Sentinel File Watcher', function() {
         })
         .then(() => {
           expect(eventFound).toBe(true);
+          expect(extraEventFound).toBe(false);
+          return watch.stop();
+        })
+        .then(done, () => {
+          watch.stop().then((err) => done.fail(err));
+        });
+    });
+
+    it('can listen for a move event', function(done) {
+      const waitTimeout = () => new Promise(resolve => {
+        setTimeout(resolve, TIMEOUT_PER_STEP);
+      });
+      const file = 'testing.file';
+      const srcInPath = path.resolve(workDir, 'test4', 'src');
+      const destInPath = path.resolve(workDir, 'test4', 'dest');
+      let eventListening = false;
+      let deleteEventFound = false;
+      let createEventFound = false;
+      let renameEventFound = false;
+      let extraEventFound = false;
+
+      function findEvent(element) {
+        if (!eventListening) {
+          return;
+        }
+        if (
+          element.action === nsfw.actions.RENAMED &&
+          element.directory === path.resolve(srcInPath) &&
+          element.oldFile === file &&
+          element.newDirectory === path.resolve(destInPath) &&
+          element.newFile === file
+        ) {
+          renameEventFound = true;
+        } else if (
+          element.action === nsfw.actions.DELETED &&
+          element.directory === path.resolve(srcInPath) &&
+          element.file === file
+        ) {
+          deleteEventFound = true;
+        } else if (
+          element.action === nsfw.actions.CREATED &&
+          element.directory === path.resolve(destInPath) &&
+          element.file === file
+        ) {
+          createEventFound = true;
+        } else {
+          if (element.file === file) {
+            extraEventFound = true;
+          }
+        }
+      }
+
+      let watch;
+
+      return nsfw(
+        workDir,
+        events => events.forEach(findEvent),
+        { debounceMS: DEBOUNCE }
+      )
+        .then(_w => {
+          watch = _w;
+          return watch.start();
+        })
+        .then(waitTimeout)
+        .then(() => {
+          fse.ensureFileSync(path.join(srcInPath, file));
+          fse.ensureDirSync(path.join(destInPath));
+        })
+        .then(waitTimeout)
+        .then(() => {
+          eventListening = true;
+          return fse.move(path.join(srcInPath, file), path.join(destInPath, file));
+        })
+        .then(waitTimeout)
+        .then(() => {
+          eventListening = false;
+        })
+        .then(() => {
+          if (isWin) {
+            expect(deleteEventFound && createEventFound).toBe(true);
+            expect(renameEventFound).toBe(false);
+          }
+          if (isLinux || isOsx) {
+            expect(renameEventFound).toBe(true);
+            expect(deleteEventFound || createEventFound).toBe(false);
+          }
           expect(extraEventFound).toBe(false);
           return watch.stop();
         })

--- a/src/win32/Watcher.cpp
+++ b/src/win32/Watcher.cpp
@@ -178,7 +178,8 @@ void Watcher::handleEvents() {
     PFILE_NOTIFY_INFORMATION info = (PFILE_NOTIFY_INFORMATION)base;
     std::wstring fileName = getWStringFileName(info->FileName, info->FileNameLength);
 
-    if (info->Action == FILE_ACTION_RENAMED_OLD_NAME) {
+    switch (info->Action) {
+    case (FILE_ACTION_RENAMED_OLD_NAME):
       if (info->NextEntryOffset != 0) {
         base += info->NextEntryOffset;
         info = (PFILE_NOTIFY_INFORMATION)base;
@@ -194,15 +195,11 @@ void Watcher::handleEvents() {
           );
         } else {
           mQueue->enqueue(DELETED, getUTF8Directory(fileName), getUTF8FileName(fileName));
-          continue;
         }
       } else {
         mQueue->enqueue(DELETED, getUTF8Directory(fileName), getUTF8FileName(fileName));
-        break;
       }
-    }
-
-    switch (info->Action) {
+      break;
     case FILE_ACTION_ADDED:
     case FILE_ACTION_RENAMED_NEW_NAME: // in the case we just receive a new name and no old name in the buffer
       mQueue->enqueue(CREATED, getUTF8Directory(fileName), getUTF8FileName(fileName));


### PR DESCRIPTION
This PR tries to fix #26, where an extra event is generated when a file is renamed on Windows.

About the fix:
What used to happen was that in the case when a rename event was generated, a 'continue' was missing and the switch was executed. The 'default' case of the switch was executed and an extra 'MODIFIED'  event was generated.