### PR TITLE
Fix types in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,13 +21,12 @@
     "url": "https://github.com/axosoft/node-simple-file-watcher/issues"
   },
   "files": [
-    "typings.d.ts",
+    "index.d.ts",
     "lib",
     "src",
     "includes",
     "binding.gyp"
   ],
-  "types": "typings.d.ts",
   "homepage": "https://github.com/axosoft/node-simple-file-watcher",
   "dependencies": {
     "fs-extra": "^7.0.0",


### PR DESCRIPTION
Types weren't included in the npm package. Hopefully this will fix it.

There was two ``types: "..."`` fields and ``index.d.ts`` wasn't included in the ``files: [...]`` array.