### PR TITLE
Address undefined behavior

### DIFF
--- a/includes/NSFW.h
+++ b/includes/NSFW.h
@@ -17,15 +17,15 @@ class NSFW : public Napi::ObjectWrap<NSFW> {
     static std::size_t instanceCount;
     static bool gcEnabled;
 
-    std::unique_ptr<NativeInterface> mInterface;
-    Napi::ThreadSafeFunction mEventCallback;
+    uint32_t mDebounceMS;
     Napi::ThreadSafeFunction mErrorCallback;
+    Napi::ThreadSafeFunction mEventCallback;
+    std::unique_ptr<NativeInterface> mInterface;
     std::mutex mInterfaceLock;
-    std::string mPath;
     std::shared_ptr<EventQueue> mQueue;
+    std::string mPath;
     std::thread mPollThread;
     std::atomic<bool> mRunning;
-    uint32_t mDebounceMS;
 
     class StartWorker: public Napi::AsyncWorker {
       public:
@@ -35,10 +35,10 @@ class NSFW : public Napi::ObjectWrap<NSFW> {
         Napi::Promise RunJob();
 
       private:
+        enum JobStatus { STARTED, ALREADY_RUNNING, COULD_NOT_START, JOB_NOT_EXECUTED_YET };
         Napi::Promise::Deferred mDeferred;
-        bool mDidStartWatching;
         NSFW *mNSFW;
-        bool mShouldUnref;
+        JobStatus mStatus;
     };
 
     Napi::Value Start(const Napi::CallbackInfo &info);

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -63,17 +63,19 @@ const buildNSFW = async (watchPath, eventCallback, { debounceMS = 500, errorCall
     throw new Error('Path to watch must be an absolute path.');
   }
 
+  let stats;
   try {
-    const stats = await fs.stat(watchPath);
-    if (stats.isDirectory()) {
-      return new NSFW(watchPath, eventCallback, { debounceMS, errorCallback });
-    } else if (stats.isFile()) {
-      return new NSFWFilePoller(watchPath, eventCallback, debounceMS);
-    } else {
-      throw new Error('Path must be a valid path to a file or a directory');
-    }
+    stats = await fs.stat(watchPath);
   } catch (e) {
     throw new Error('Path must be a valid path to a file or a directory.');
+  }
+
+  if (stats.isDirectory()) {
+    return new NSFW(watchPath, eventCallback, { debounceMS, errorCallback });
+  } else if (stats.isFile()) {
+    return new NSFWFilePoller(watchPath, eventCallback, debounceMS);
+  } else {
+    throw new Error('Path must be a valid path to a file or a directory');
   }
 };
 


### PR DESCRIPTION
TIL when running the optimizer while compiling, if you don't include a mutex in a function with a variable that is shared across threads, it basically tells the optimizer that it's safe to assume that this method is single threaded.

Running: the code provided here in g++ with -O3 enabled will cause this program to loop infinitely. 
https://devblogs.microsoft.com/oldnewthing/20180924-00/?p=99805

Thanks to @ianhattendorf for showing me this. I can concede when I'm visibly wrong :smile:.