### PR TITLE
Fixed file renaming on Windows

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,9 @@
   "extends": "eslint:recommended",
   "rules": {
     "max-len": [2, 120],
-    "indent": [2, 2],
+    "indent": [2, 2, {
+      "SwitchCase": 1
+    }],
     "no-console": 1,
     "no-const-assign": 2,
     "no-mixed-spaces-and-tabs": 2,

--- a/js/spec/index-spec.js
+++ b/js/spec/index-spec.js
@@ -204,10 +204,9 @@ describe('Node Sentinel File Watcher', function() {
       const waitTimeout = () => new Promise(resolve => {
         setTimeout(resolve, TIMEOUT_PER_STEP);
       });
-      const srcFile = 'testing0.file';
-      const destFile = 'testing1.file';
-      const srcInPath = path.resolve(workDir, 'test4', 'srcfolder');
-      const destInPath = path.resolve(workDir, 'test4', 'destfolder');
+      const srcFile = 'testing.file';
+      const destFile = 'new-testing.file';
+      const inPath = path.resolve(workDir, 'test4');
       let eventListening = false;
       let eventFound = false;
       let extraEventFound = false;
@@ -218,14 +217,16 @@ describe('Node Sentinel File Watcher', function() {
         }
         if (
           element.action === nsfw.actions.RENAMED &&
-          element.directory === path.resolve(srcInPath) &&
+          element.directory === path.resolve(inPath) &&
           element.oldFile === srcFile &&
-          element.newDirectory === path.resolve(destInPath) &&
+          element.newDirectory === path.resolve(inPath) &&
           element.newFile === destFile
         ) {
           eventFound = true;
         } else {
-          extraEventFound = true;
+          if (element.directory === path.resolve(inPath)) {
+            extraEventFound = true;
+          }
         }
       }
 
@@ -242,13 +243,12 @@ describe('Node Sentinel File Watcher', function() {
         })
         .then(waitTimeout)
         .then(() => {
-          fse.ensureFileSync(path.join(srcInPath, srcFile));
-          fse.ensureDirSync(destInPath);
+          fse.ensureFileSync(path.join(inPath, srcFile));
         })
         .then(waitTimeout)
         .then(() => {
           eventListening = true;
-          return fse.move(path.join(srcInPath, srcFile), path.join(destInPath, destFile));
+          return fse.move(path.join(inPath, srcFile), path.join(inPath, destFile));
         })
         .then(waitTimeout)
         .then(() => {

--- a/js/spec/index-spec.js
+++ b/js/spec/index-spec.js
@@ -211,7 +211,9 @@ describe('Node Sentinel File Watcher', function() {
       const destFile = 'new-testing.file';
       const inPath = path.resolve(workDir, 'test4');
       let eventListening = false;
-      let eventFound = false;
+      let deleteEventFound = false;
+      let createEventFound = false;
+      let renameEventFound = false;
       let extraEventFound = false;
 
       function findEvent(element) {
@@ -225,7 +227,19 @@ describe('Node Sentinel File Watcher', function() {
           element.newDirectory === path.resolve(inPath) &&
           element.newFile === destFile
         ) {
-          eventFound = true;
+          renameEventFound = true;
+        } else if (
+          element.action === nsfw.actions.DELETED &&
+          element.directory === path.resolve(inPath) &&
+          element.file === srcFile
+        ) {
+          deleteEventFound = true;
+        } else if (
+          element.action === nsfw.actions.CREATED &&
+          element.directory === path.resolve(inPath) &&
+          element.file === destFile
+        ) {
+          createEventFound = true;
         } else {
           if (element.directory === path.resolve(inPath)) {
             extraEventFound = true;
@@ -258,7 +272,14 @@ describe('Node Sentinel File Watcher', function() {
           eventListening = false;
         })
         .then(() => {
-          expect(eventFound).toBe(true);
+          if (isOsx) {
+            // on osx it could be either a rename event or one delete and one create event
+            expect(deleteEventFound && createEventFound).not.toBe(renameEventFound);
+          }
+          if (isWin || isLinux) {
+            expect(renameEventFound).toBe(true);
+            expect(deleteEventFound || createEventFound).toBe(false);
+          }
           expect(extraEventFound).toBe(false);
           return watch.stop();
         })
@@ -337,11 +358,11 @@ describe('Node Sentinel File Watcher', function() {
           eventListening = false;
         })
         .then(() => {
-          if (isWin) {
+          if (isWin || isOsx) {
             expect(deleteEventFound && createEventFound).toBe(true);
             expect(renameEventFound).toBe(false);
           }
-          if (isLinux || isOsx) {
+          if (isLinux) {
             expect(renameEventFound).toBe(true);
             expect(deleteEventFound || createEventFound).toBe(false);
           }

--- a/src/NSFW.cpp
+++ b/src/NSFW.cpp
@@ -227,7 +227,7 @@ void NSFW::pollForEvents() {
 
               if ((*events)[i]->type == RENAMED) {
                 event["oldFile"] = Napi::String::New(env, (*events)[i]->fromFile);
-                event["oldDirectory"] = Napi::String::New(env, (*events)[i]->toDirectory);
+                event["newDirectory"] = Napi::String::New(env, (*events)[i]->toDirectory);
                 event["newFile"] = Napi::String::New(env, (*events)[i]->toFile);
               } else {
                 event["file"] = Napi::String::New(env, (*events)[i]->fromFile);

--- a/src/win32/Watcher.cpp
+++ b/src/win32/Watcher.cpp
@@ -194,7 +194,8 @@ void Watcher::handleEvents() {
     PFILE_NOTIFY_INFORMATION info = (PFILE_NOTIFY_INFORMATION)base;
     std::wstring fileName = getWStringFileName(info->FileName, info->FileNameLength);
 
-    if (info->Action == FILE_ACTION_RENAMED_OLD_NAME) {
+    switch (info->Action) {
+    case (FILE_ACTION_RENAMED_OLD_NAME):
       if (info->NextEntryOffset != 0) {
         base += info->NextEntryOffset;
         info = (PFILE_NOTIFY_INFORMATION)base;
@@ -210,15 +211,11 @@ void Watcher::handleEvents() {
           );
         } else {
           mQueue->enqueue(DELETED, getUTF8Directory(fileName), getUTF8FileName(fileName));
-          continue;
         }
       } else {
         mQueue->enqueue(DELETED, getUTF8Directory(fileName), getUTF8FileName(fileName));
-        break;
       }
-    }
-
-    switch (info->Action) {
+      break;
     case FILE_ACTION_ADDED:
     case FILE_ACTION_RENAMED_NEW_NAME: // in the case we just receive a new name and no old name in the buffer
       mQueue->enqueue(CREATED, getUTF8Directory(fileName), getUTF8FileName(fileName));


### PR DESCRIPTION
This is a reopen with some touch ups to #86. Namely that we now use async/await in our tests. Fortunately, this test suite really came in handy, because it caught a bug in the Napi refactor. Awesome!
