### PR TITLE
Revert Napi changes

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -5,27 +5,22 @@
         "sources": [
             "src/NSFW.cpp",
             "src/Queue.cpp",
-            "src/NativeInterface.cpp"
+            "src/NativeInterface.cpp",
+            "includes/NSFW.h",
+            "includes/Queue.h",
+            "includes/NativeInterface.h"
         ],
         "include_dirs": [
-            "includes",
-            "<!@(node -p \"require('node-addon-api').include\")"
+            "<!(node -e \"require('nan')\")",
+            "includes"
         ],
-        "cflags!": ["-fno-exceptions"],
-        "cflags_cc!": ["-fno-exceptions"],
-        "xcode_settings": {
-            "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
-            "CLANG_CXX_LIBRARY": "libc++",
-            "MACOSX_DEPLOYMENT_TARGET": "10.7",
-        },
-        "msvs_settings": {
-            "VCCLCompilerTool": { "ExceptionHandling": 1 },
-        },
         "conditions": [
             ["OS=='win'", {
                 "sources": [
                     "src/win32/Controller.cpp",
-                    "src/win32/Watcher.cpp"
+                    "src/win32/Watcher.cpp",
+                    "includes/win32/Controller.h",
+                    "includes/win32/Watcher.h"
                 ],
                 "msvs_settings": {
                     "VCCLCompilerTool": {
@@ -37,14 +32,14 @@
                 }
             }],
             ["OS=='mac'", {
-                "cflags+": ["-fvisibility-hidden"],
                 "sources": [
                     "src/osx/RunLoop.cpp",
-                    "src/osx/FSEventsService.cpp"
+                    "src/osx/FSEventsService.cpp",
+                    "includes/osx/RunLoop.h",
+                    "includes/osx/FSEventsService.h"
                 ],
                 "xcode_settings": {
-                    "GCC_SYMBOLS_PRIVATE_EXTERN": "YES", # -fvisibility=hidden
-                    "MACOSX_DEPLOYMENT_TARGET": "10.7",
+                    'MACOSX_DEPLOYMENT_TARGET': '10.7',
                     "OTHER_CFLAGS": [
                         "-std=c++11",
                         "-stdlib=libc++"
@@ -65,7 +60,10 @@
                 "sources": [
                     "src/linux/InotifyEventLoop.cpp",
                     "src/linux/InotifyTree.cpp",
-                    "src/linux/InotifyService.cpp"
+                    "src/linux/InotifyService.cpp",
+                    "includes/linux/InotifyEventLoop.h",
+                    "includes/linux/InotifyTree.h",
+                    "includes/linux/InotifyService.h"
                 ],
                 "cflags": [
                     "-Wno-unknown-pragmas",
@@ -102,7 +100,7 @@
                 ],
                 "libraries": [
                     "-L/usr/local/lib",
-                    "-linotify" 
+                    "-linotify"
                 ]
             }],
         ]

--- a/js/spec/index-spec.js
+++ b/js/spec/index-spec.js
@@ -673,14 +673,4 @@ describe('Node Sentinel File Watcher', function() {
       }
     });
   });
-
-  describe('Garbage collection', function() {
-    it('can garbage collect all instances', async function () {
-      this.timeout(60000);
-      while (nsfw.getAllocatedInstanceCount() > 0) {
-        global.gc();
-        await sleep(0);
-      }
-    });
-  });
 });

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "homepage": "https://github.com/axosoft/node-simple-file-watcher",
   "dependencies": {
-    "node-addon-api": "*"
+    "nan": "^2.0.0"
   },
   "devDependencies": {
     "eslint": "^6.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -894,6 +894,11 @@ mute-stream@0.0.8:
   resolved "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
+nan@^2.0.0:
+  version "2.14.0"
+  resolved "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
+  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -903,11 +908,6 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
-
-node-addon-api@*:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.0.tgz#f9afb8d777a91525244b01775ea0ddbe1125483b"
-  integrity sha512-ASCL5U13as7HhOExbT6OlWJJUV/lLzL2voOSP1UVehpRD8FbSrSDjfScK/KwAvVTI5AS6r4VwbOMlIqtvRidnA==
 
 node-environment-flags@1.0.6:
   version "1.0.6"


### PR DESCRIPTION
These changes are breaking after all, because Napi v4 is not supported in <10.16.0. Users will be forced to update to 10.16.0 or higher to get these changes. I will publish these changes as 1.2.9 and then release a 2.0.0 with the Napi changes and an engines field to prevent users who are on older versions of Node from getting bit by these changes.