### PR TITLE
linux: support ignore regex pattern

### DIFF
--- a/includes/NSFW.h
+++ b/includes/NSFW.h
@@ -5,6 +5,7 @@
 #include <chrono>
 #include <memory>
 #include <napi.h>
+#include <regex>
 #include <thread>
 #include <vector>
 
@@ -24,6 +25,7 @@ class NSFW : public Napi::ObjectWrap<NSFW> {
     std::mutex mInterfaceLock;
     std::shared_ptr<EventQueue> mQueue;
     std::string mPath;
+    std::vector<std::regex> mIgnorePathRegexVector;
     std::thread mPollThread;
     std::atomic<bool> mRunning;
 
@@ -62,6 +64,7 @@ class NSFW : public Napi::ObjectWrap<NSFW> {
     static Napi::Object Init(Napi::Env, Napi::Object exports);
     static Napi::Value InstanceCount(const Napi::CallbackInfo &info);
     void pollForEvents();
+    bool ignorePath(std::string path);
 
     NSFW(const Napi::CallbackInfo &info);
     ~NSFW();

--- a/includes/NativeInterface.h
+++ b/includes/NativeInterface.h
@@ -13,11 +13,15 @@ using NativeImplementation = InotifyService;
 #endif
 
 #include "Queue.h"
+#include <functional>
 #include <vector>
 
 class NativeInterface {
 public:
-  NativeInterface(const std::string &path, std::shared_ptr<EventQueue> queue);
+  NativeInterface(
+    const std::string &path,
+    std::shared_ptr<EventQueue> queue,
+    std::function<bool(std::string path)> ignorePath);
   ~NativeInterface();
 
   std::string getError();
@@ -26,6 +30,7 @@ public:
 
 private:
   std::unique_ptr<NativeImplementation> mNativeInterface;
+  std::function<bool(std::string path)> mIgnorePath;
 };
 
 #endif

--- a/includes/linux/InotifyService.h
+++ b/includes/linux/InotifyService.h
@@ -4,6 +4,7 @@
 #include "InotifyEventLoop.h"
 #include "InotifyTree.h"
 #include "../Queue.h"
+#include <functional>
 #include <queue>
 #include <map>
 
@@ -12,7 +13,7 @@ class InotifyTree;
 
 class InotifyService {
 public:
-  InotifyService(std::shared_ptr<EventQueue> queue, std::string path);
+  InotifyService(std::shared_ptr<EventQueue> queue, std::string path, std::function<bool(std::string path)> ignorePath);
 
   std::string getError();
   bool hasErrored();
@@ -33,6 +34,7 @@ private:
 
   InotifyEventLoop *mEventLoop;
   std::shared_ptr<EventQueue> mQueue;
+  std::function<bool(std::string path)> mIgnorePath;
   InotifyTree *mTree;
   int mInotifyInstance;
 

--- a/includes/linux/InotifyTree.h
+++ b/includes/linux/InotifyTree.h
@@ -5,6 +5,7 @@
 #include <dirent.h>
 #include <stdlib.h>
 #include <fcntl.h>
+#include <functional>
 #include <errno.h>
 #include <sstream>
 #include <vector>
@@ -13,7 +14,7 @@
 
 class InotifyTree {
 public:
-  InotifyTree(int inotifyInstance, std::string path);
+  InotifyTree(int inotifyInstance, std::string path, std::function<bool(std::string path)> ignorePath);
 
   void addDirectory(int wd, std::string name);
   std::string getError();
@@ -31,6 +32,7 @@ private:
     InotifyNode(
       InotifyTree *tree,
       int inotifyInstance,
+      std::function<bool(std::string path)> ignorePath,
       InotifyNode *parent,
       std::string directory,
       std::string name,
@@ -68,6 +70,7 @@ private:
     std::string mFullPath;
     ino_t mInodeNumber;
     const int mInotifyInstance;
+    std::function<bool(std::string path)> mIgnorePath;
     std::string mName;
     InotifyNode *mParent;
     InotifyTree *mTree;
@@ -83,6 +86,7 @@ private:
 
   std::string mError;
   const int mInotifyInstance;
+  std::function<bool(std::string path)> mIgnorePath;
   std::map<int, InotifyNode *> *mInotifyNodeByWatchDescriptor;
   std::unordered_set<ino_t> inodes;
   InotifyNode *mRoot;

--- a/index.d.ts
+++ b/index.d.ts
@@ -54,7 +54,9 @@ declare module 'nsfw' {
     interface Options {
         /** time in milliseconds to debounce the event callback */
         debounceMS?: number;
-        /**  callback to fire in the case of errors */
-        errorCallback: (err: any) => void
+        /** callback to fire in the case of errors */
+        errorCallback: (err: any) => void;
+        /** js regex array to filter which path to watch or not */
+        ignorePathRegexArray?: string[];
     }
 }

--- a/js/spec/index-spec.js
+++ b/js/spec/index-spec.js
@@ -534,6 +534,12 @@ describe('Node Sentinel File Watcher', function() {
         watch = null;
       }
     });
+
+    if (process.platform === 'linux') {
+      it('can cut part of the watch tree (linux)', async function () {
+        // todo
+      });
+    }
   });
 
   describe('Errors', function() {

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -48,7 +48,7 @@ function NSFWFilePoller(watchPath, eventCallback, debounceMS) {
 }
 
 
-const buildNSFW = async (watchPath, eventCallback, { debounceMS = 500, errorCallback: _errorCallback } = {}) => {
+const buildNSFW = async (watchPath, eventCallback, { debounceMS = 500, errorCallback: _errorCallback, pathIgnoreRegexArray } = {}) => {
   if (Number.isInteger(debounceMS)) {
     if (debounceMS < 1) {
       throw new Error('Minimum debounce is 1ms.');
@@ -71,7 +71,7 @@ const buildNSFW = async (watchPath, eventCallback, { debounceMS = 500, errorCall
   }
 
   if (stats.isDirectory()) {
-    return new NSFW(watchPath, eventCallback, { debounceMS, errorCallback });
+    return new NSFW(watchPath, eventCallback, { debounceMS, errorCallback, pathIgnoreRegexArray });
   } else if (stats.isFile()) {
     return new NSFWFilePoller(watchPath, eventCallback, debounceMS);
   } else {

--- a/src/NativeInterface.cpp
+++ b/src/NativeInterface.cpp
@@ -1,7 +1,7 @@
 #include "../includes/NativeInterface.h"
 
-NativeInterface::NativeInterface(const std::string &path, std::shared_ptr<EventQueue> queue) {
-  mNativeInterface.reset(new NativeImplementation(queue, path));
+NativeInterface::NativeInterface(const std::string &path, std::shared_ptr<EventQueue> queue, std::function<bool(std::string path)> ignorePath) {
+  mNativeInterface.reset(new NativeImplementation(queue, path, ignorePath));
 }
 
 NativeInterface::~NativeInterface() {

--- a/src/linux/InotifyService.cpp
+++ b/src/linux/InotifyService.cpp
@@ -1,8 +1,9 @@
 #include "../../includes/linux/InotifyService.h"
 
-InotifyService::InotifyService(std::shared_ptr<EventQueue> queue, std::string path):
+InotifyService::InotifyService(std::shared_ptr<EventQueue> queue, std::string path, std::function<bool(std::string path)> ignorePath):
   mEventLoop(NULL),
   mQueue(queue),
+  mIgnorePath(ignorePath),
   mTree(NULL) {
   mInotifyInstance = inotify_init();
 
@@ -10,7 +11,7 @@ InotifyService::InotifyService(std::shared_ptr<EventQueue> queue, std::string pa
     return;
   }
 
-  mTree = new InotifyTree(mInotifyInstance, path);
+  mTree = new InotifyTree(mInotifyInstance, path, mIgnorePath);
   if (!mTree->isRootAlive()) {
     delete mTree;
     mTree = NULL;


### PR DESCRIPTION
This is a first pass at implementing some mechanism to filter paths.
Right now, we use the regex engine from the C++ standard library, but
this engine behaves differently than the most common one used by recent
JS runtimes.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>