### PR TITLE
add events pausing

### DIFF
--- a/includes/NSFW.h
+++ b/includes/NSFW.h
@@ -67,7 +67,7 @@ class NSFW : public Napi::ObjectWrap<NSFW> {
 
       private:
         Napi::Promise::Deferred mDeferred;
-        bool mDidPauseEvents;
+        std::atomic<bool> mDidPauseEvents;
         NSFW *mNSFW;
     };
 
@@ -82,7 +82,7 @@ class NSFW : public Napi::ObjectWrap<NSFW> {
 
       private:
         Napi::Promise::Deferred mDeferred;
-        bool mDidResumeEvents;
+        std::atomic<bool> mDidResumeEvents;
         NSFW *mNSFW;
     };
 

--- a/includes/NSFW.h
+++ b/includes/NSFW.h
@@ -24,7 +24,6 @@ class NSFW : public Napi::ObjectWrap<NSFW> {
     std::mutex mInterfaceLock;
     std::shared_ptr<EventQueue> mQueue;
     std::string mPath;
-    std::atomic<bool> mPaused;
     std::thread mPollThread;
     std::atomic<bool> mRunning;
 
@@ -92,6 +91,8 @@ class NSFW : public Napi::ObjectWrap<NSFW> {
   public:
     static Napi::Object Init(Napi::Env, Napi::Object exports);
     static Napi::Value InstanceCount(const Napi::CallbackInfo &info);
+    void pauseQueue();
+    void resumeQueue();
     void pollForEvents();
 
     NSFW(const Napi::CallbackInfo &info);

--- a/includes/Queue.h
+++ b/includes/Queue.h
@@ -47,9 +47,15 @@ public:
     const std::string &toFile = ""
   );
 
+  void pause();
+  void resume();
+
+  EventQueue();
+
 private:
   std::deque<std::unique_ptr<Event>> queue;
   std::mutex mutex;
+  bool mPaused;
 };
 
 #endif

--- a/includes/Queue.h
+++ b/includes/Queue.h
@@ -6,6 +6,7 @@
 #include <deque>
 #include <vector>
 #include <mutex>
+#include <atomic>
 
 enum EventType {
   CREATED = 0,
@@ -55,7 +56,7 @@ public:
 private:
   std::deque<std::unique_ptr<Event>> queue;
   std::mutex mutex;
-  bool mPaused;
+  std::atomic<bool> mPaused;
 };
 
 #endif

--- a/js/spec/index-spec.js
+++ b/js/spec/index-spec.js
@@ -565,7 +565,7 @@ describe('Node Sentinel File Watcher', function() {
         await watch.start();
         await watch.pause();
         await sleep(TIMEOUT_PER_STEP);
-        await fse.writeFile(path.join(inPath, file), 'Never mind.');
+        await fse.writeFile(path.join(inPath, file), 'You will not see me.');
         await sleep(TIMEOUT_PER_STEP);
 
         assert.ok(!eventFound);
@@ -574,7 +574,7 @@ describe('Node Sentinel File Watcher', function() {
         await sleep(TIMEOUT_PER_STEP);
         assert.ok(!eventFound);
 
-        await fse.writeFile(path.join(inPath, file), 'Never mind.');
+        await fse.writeFile(path.join(inPath, file), 'But you will see me.');
         await sleep(TIMEOUT_PER_STEP);
 
         assert.ok(eventFound);

--- a/js/spec/index-spec.js
+++ b/js/spec/index-spec.js
@@ -544,7 +544,10 @@ describe('Node Sentinel File Watcher', function() {
 
       function findEvent(element) {
         if (
-          element.action === nsfw.actions.CREATED &&
+          (
+            element.action === nsfw.actions.CREATED ||
+            element.action === nsfw.actions.MODIFIED
+          ) &&
           element.directory === path.resolve(inPath) &&
           element.file === file
         ) {
@@ -562,12 +565,16 @@ describe('Node Sentinel File Watcher', function() {
         await watch.start();
         await watch.pause();
         await sleep(TIMEOUT_PER_STEP);
-        await fse.writeFile(path.join(inPath, file), 'Peanuts, on occasion, rain from the skies.');
+        await fse.writeFile(path.join(inPath, file), 'Never mind.');
         await sleep(TIMEOUT_PER_STEP);
 
         assert.ok(!eventFound);
 
         await watch.resume();
+        await sleep(TIMEOUT_PER_STEP);
+        assert.ok(!eventFound);
+
+        await fse.writeFile(path.join(inPath, file), 'Never mind.');
         await sleep(TIMEOUT_PER_STEP);
 
         assert.ok(eventFound);

--- a/js/spec/index-spec.js
+++ b/js/spec/index-spec.js
@@ -536,6 +536,48 @@ describe('Node Sentinel File Watcher', function() {
     });
   });
 
+  describe('Pausing', function () {
+    it('can pause and resume event reporting', async function () {
+      const file = 'another_test.file';
+      const inPath = path.resolve(workDir, 'test2', 'folder2');
+      let eventFound = false;
+
+      function findEvent(element) {
+        if (
+          element.action === nsfw.actions.CREATED &&
+          element.directory === path.resolve(inPath) &&
+          element.file === file
+        ) {
+          eventFound = true;
+        }
+      }
+
+      let watch = await nsfw(
+        workDir,
+        events => events.forEach(findEvent),
+        { debounceMS: DEBOUNCE }
+      );
+
+      try {
+        await watch.start();
+        await watch.pause();
+        await sleep(TIMEOUT_PER_STEP);
+        await fse.writeFile(path.join(inPath, file), 'Peanuts, on occasion, rain from the skies.');
+        await sleep(TIMEOUT_PER_STEP);
+
+        assert.ok(!eventFound);
+
+        await watch.resume();
+        await sleep(TIMEOUT_PER_STEP);
+
+        assert.ok(eventFound);
+      } finally {
+        await watch.stop();
+        watch = null;
+      }
+    });
+  });
+
   describe('Errors', function() {
     it('can gracefully recover when the watch folder is deleted', async function() {
       const inPath = path.join(workDir, 'test4');

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -45,6 +45,10 @@ function NSFWFilePoller(watchPath, eventCallback, debounceMS) {
   this.stop = async () => {
     clearInterval(filePollerInterval);
   };
+
+  // Because I'm not that concerned about pausing a single-file watcher
+  this.pause = () => Promise.resolve();
+  this.resume = () => Promise.resolve();
 }
 
 
@@ -88,6 +92,8 @@ function nsfw(watchPath, eventCallback, options) {
 
   this.start = () => implementation.start();
   this.stop = () => implementation.stop();
+  this.pause = () => implementation.pause();
+  this.resume = () => implementation.resume();
 }
 
 nsfw.actions = {

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -46,9 +46,8 @@ function NSFWFilePoller(watchPath, eventCallback, debounceMS) {
     clearInterval(filePollerInterval);
   };
 
-  // Because I'm not that concerned about pausing a single-file watcher
-  this.pause = () => Promise.resolve();
-  this.resume = () => Promise.resolve();
+  this.pause = () => this.stop();
+  this.resume = () => this.start();
 }
 
 

--- a/src/NSFW.cpp
+++ b/src/NSFW.cpp
@@ -255,7 +255,9 @@ Napi::Value NSFW::Resume(const Napi::CallbackInfo &info) {
 void NSFW::pollForEvents() {
   while (mRunning) {
     uint32_t sleepDuration = 50;
-    if (!mPaused) {
+    if (mPaused) {
+      mQueue->clear();
+    } else {
       std::lock_guard<std::mutex> lock(mInterfaceLock);
 
       if (mInterface->hasErrored()) {

--- a/src/Queue.cpp
+++ b/src/Queue.cpp
@@ -50,6 +50,21 @@ void EventQueue::enqueue(
   const std::string &toDirectory,
   const std::string &toFile
 ) {
+  if (mPaused) {
+    return;
+  }
   std::lock_guard<std::mutex> lock(mutex);
   queue.emplace_back(std::unique_ptr<Event>(new Event(type, fromDirectory, fromFile, toDirectory, toFile)));
 }
+
+void EventQueue::pause() {
+  mPaused = true;
+}
+
+void EventQueue::resume() {
+  mPaused = false;
+}
+
+EventQueue::EventQueue():
+  mPaused(false)
+{}

--- a/src/Queue.cpp
+++ b/src/Queue.cpp
@@ -59,6 +59,7 @@ void EventQueue::enqueue(
 
 void EventQueue::pause() {
   mPaused = true;
+  clear();
 }
 
 void EventQueue::resume() {


### PR DESCRIPTION
Add functionality to pause event reporting for e.g. when a large operation is going on and we don't care about file events while it's going on. The queue just keeps collecting events until the unpause, then a single large event report happens.