### PR TITLE
fix gc issue and update typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -60,8 +60,8 @@ declare module 'nsfw' {
         interface Options {
             /** time in milliseconds to debounce the event callback */
             debounceMS?: number;
-            /**  callback to fire in the case of errors */
-            errorCallback: (err: any) => void
+            /** callback to fire in the case of errors */
+            errorCallback?: (err: any) => void
         }
     }
 

--- a/js/spec/index-spec.js
+++ b/js/spec/index-spec.js
@@ -562,6 +562,31 @@ describe('Node Sentinel File Watcher', function() {
         watch = null;
       }
     });
+
+    it('Can pass falsy values to errorCallback', async function() {
+      const ok = [undefined, null, 0, '', false];
+      const notOk = [1, true, 'a', {}, []];
+      await Promise.all([
+        ...ok.map(async errorCallback => nsfw(
+          workDir,
+          () => {},
+          { errorCallback }
+        )),
+        ...notOk.map(async errorCallback => {
+          try {
+            await nsfw(
+              workDir,
+              () => {},
+              { errorCallback },
+            );
+          } catch (error) {
+            assert.ok(error.message === 'options.errorCallback must be a function.');
+            return;
+          }
+          assert.fail('nsfw must error if errorCallback is not a function nor a falsy value');
+        })
+      ]);
+    });
   });
 
   describe('Stress', function() {

--- a/js/spec/index-spec.js
+++ b/js/spec/index-spec.js
@@ -684,6 +684,15 @@ describe('Node Sentinel File Watcher', function() {
   describe('Garbage collection', function() {
     it('can garbage collect all instances', async function () {
       this.timeout(60000);
+      let threw = false;
+      try {
+        // Try to get an error coming from the C++ constructor by passing a bad callback
+        await nsfw(workDir, () => {}, { errorCallback: 'not a callback' });
+      } catch (e) {
+        threw = true;
+      } if (!threw) {
+        assert.fail('nsfw must throw when provided a bad callback');
+      }
       while (nsfw.getAllocatedInstanceCount() > 0) {
         global.gc();
         await sleep(0);

--- a/src/NSFW.cpp
+++ b/src/NSFW.cpp
@@ -12,10 +12,6 @@ NSFW::NSFW(const Napi::CallbackInfo &info):
   mPath(""),
   mRunning(false)
 {
-  if (gcEnabled) {
-    instanceCount++;
-  }
-
   auto env = info.Env();
   if (info.Length() < 1 || !info[0].IsString()) {
     throw Napi::TypeError::New(env, "Must pass a string path as the first argument to NSFW.");
@@ -70,6 +66,10 @@ NSFW::NSFW(const Napi::CallbackInfo &info):
       0,
       1
     );
+  }
+
+  if (gcEnabled) {
+    instanceCount++;
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/Axosoft/nsfw/issues/130

Commit 1:

Fix allocation counting bug when throwing errors in the constructor.

Commit 2:

`NSFW.cpp` actually supports non-function values for `errorCallback`.

This commit aligns the typings with the implementation. Note that I
added an extra check for `undefined` in the error processing because
someone might define options as `{ errorCallback: undefined }`, in which
case `options.Has("errorCallback")` will return `true`, so we want to handle
that extra scenario since the typings will accept `undefined` as a value.