### PR TITLE
win: fix race condition when starting a watcher

### DIFF
--- a/includes/win32/Watcher.h
+++ b/includes/win32/Watcher.h
@@ -36,6 +36,7 @@ class Watcher
 
     std::atomic<bool> mRunning;
     SingleshotSemaphore mHasStartedSemaphore;
+    SingleshotSemaphore mIsRunningSemaphore;
     mutable std::mutex mErrorMutex;
     std::string mError;
 


### PR DESCRIPTION
The `mRunner` thread sometimes runs after a delay, leading to a state
where `mRunning` is false and `pollDirectoryChanges` is called and does
nothing.

Fixes https://github.com/Axosoft/nsfw/issues/131