### PR TITLE
Support file names that start with uncode characters on linux

### DIFF
--- a/js/spec/index-spec.js
+++ b/js/spec/index-spec.js
@@ -704,6 +704,39 @@ describe('Node Sentinel File Watcher', function() {
         watch = null;
       }
     });
+
+    it('supports watching unicode directories and uncode files', async function() {
+      const file = 'は.starts_with_unicode';
+      let eventFound = false;
+
+      function findEvent(element) {
+        if (
+          element.action === nsfw.actions.CREATED &&
+          element.directory === watchPath &&
+          element.file === file
+        ) {
+          eventFound = true;
+        }
+      }
+
+      let watch = await nsfw(
+        workDir,
+        events => events.forEach(findEvent),
+        { debounceMS: DEBOUNCE }
+      );
+
+      try {
+        await watch.start();
+        await sleep(TIMEOUT_PER_STEP);
+        await fse.writeFile(path.join(watchPath, file), 'Unicode though.');
+        await sleep(TIMEOUT_PER_STEP);
+
+        assert.ok(eventFound);
+      } finally {
+        await watch.stop();
+        watch = null;
+      }
+    });
   });
 
   describe('Garbage collection', function() {

--- a/src/linux/InotifyEventLoop.cpp
+++ b/src/linux/InotifyEventLoop.cpp
@@ -108,10 +108,6 @@ void InotifyEventLoop::work() {
       isDirectoryRemoval = event->mask & (uint32_t)(IN_IGNORED | IN_DELETE_SELF);
       isDirectoryEvent = event->mask & (uint32_t)(IN_ISDIR);
 
-      if (!isDirectoryRemoval && *event->name <= 31) {
-        continue;
-      }
-
       if (event->mask & (uint32_t)(IN_ATTRIB | IN_MODIFY)) {
         modify();
       } else if (event->mask & (uint32_t)IN_CREATE) {


### PR DESCRIPTION
Fixes issue #69
If file name starts with unicode character (ex. Cyrillic or Chinese) nsfw will not send event for it. Now it will send an event.

Signed-off-by: Alexander Kozinko <kozav@1c.ru>