### PR TITLE
Windows emits too many events

### DIFF
--- a/src/win32/Watcher.cpp
+++ b/src/win32/Watcher.cpp
@@ -146,12 +146,7 @@ bool Watcher::pollDirectoryChanges() {
     TRUE,                           // recursive watching
     FILE_NOTIFY_CHANGE_FILE_NAME
     | FILE_NOTIFY_CHANGE_DIR_NAME
-    | FILE_NOTIFY_CHANGE_ATTRIBUTES
-    | FILE_NOTIFY_CHANGE_SIZE
-    | FILE_NOTIFY_CHANGE_LAST_WRITE
-    | FILE_NOTIFY_CHANGE_LAST_ACCESS
-    | FILE_NOTIFY_CHANGE_CREATION
-    | FILE_NOTIFY_CHANGE_SECURITY,
+    | FILE_NOTIFY_CHANGE_LAST_WRITE,
     &bytes,                         // num bytes written
     &mOverlapped,
     [](DWORD errorCode, DWORD numBytes, LPOVERLAPPED overlapped) {


### PR DESCRIPTION
This PR fixes https://github.com/Axosoft/nsfw/issues/121

By simply copying what the standard .NET runtime on Windows does when using their file system watcher class out of the box: 

```
continueExecuting = Interop.Kernel32.ReadDirectoryChangesW(
  state.DirectoryHandle,
  state.Buffer, // the buffer is kept pinned for the duration of the sync and async operation by the PreAllocatedOverlapped
  _internalBufferSize,
  _includeSubdirectories,
  (uint)_notifyFilters,
  null,
  overlappedPointer,
  null
);
```
([source](https://github.com/dotnet/runtime/blob/c344d64b05a5530fa3a633a2e993f7bb7ca163fb/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Win32.cs#L158-L166))

Where `_notifyFilters` is: `NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.DirectoryName`
([source](https://github.com/dotnet/runtime/blob/c344d64b05a5530fa3a633a2e993f7bb7ca163fb/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.cs#L29))