### PR TITLE
macOS - improve `demangle` to emit create events

### DIFF
--- a/includes/osx/FSEventsService.h
+++ b/includes/osx/FSEventsService.h
@@ -41,7 +41,7 @@ public:
   ~FSEventsService();
 private:
   void create(std::string path);
-  void demangle(std::string path);
+  void demangle(std::string path, bool gotCreatedOrRenamed);
   void dispatch(EventType action, std::string path);
   void modify(std::string path);
   void remove(std::string path);


### PR DESCRIPTION
Fixes https://github.com/Axosoft/nsfw/issues/31

The current implementation of `demangle` has a flaw: some operations from the macOS finder can result in the `birthtime` getting restored as it was (e.g. undo a delete or copy a folder). As such, `nsfw` often would wrongly only send a change event when it is a create event.

For some operations we can tell that the event should be create, so a boolean flag is added. The current behaviour of sending a change event is still preserved, so we might be ending up sending one event too much, but I think that is totally fine.

This slightly improves the situation for https://github.com/Axosoft/nsfw/issues/146 in that a create event is fired for the renamed file, though we miss the delete event. I think detecting a case rename will probably be tricky for `demangle` because the stat check will not figure out that the old name was removed from disk.