### PR TITLE
Fix segfault on exit from an electron app

### DIFF
--- a/includes/NSFW.h
+++ b/includes/NSFW.h
@@ -26,6 +26,7 @@ class NSFW : public Napi::ObjectWrap<NSFW> {
     std::string mPath;
     std::thread mPollThread;
     std::atomic<bool> mRunning;
+    std::atomic<bool> mFinalizing;
 
     class StartWorker: public Napi::AsyncWorker {
       public:
@@ -95,6 +96,7 @@ class NSFW : public Napi::ObjectWrap<NSFW> {
     void resumeQueue();
     void pollForEvents();
 
+    void Finalize(Napi::Env env);
     NSFW(const Napi::CallbackInfo &info);
     ~NSFW();
 };

--- a/includes/NSFW.h
+++ b/includes/NSFW.h
@@ -28,6 +28,7 @@ class NSFW : public Napi::ObjectWrap<NSFW> {
     std::atomic<bool> mRunning;
     std::atomic<bool> mFinalizing;
     std::condition_variable mWaitPoolEvents;
+    std::mutex mRunningLock;
 
     class StartWorker: public Napi::AsyncWorker {
       public:

--- a/includes/NSFW.h
+++ b/includes/NSFW.h
@@ -27,6 +27,7 @@ class NSFW : public Napi::ObjectWrap<NSFW> {
     std::thread mPollThread;
     std::atomic<bool> mRunning;
     std::atomic<bool> mFinalizing;
+    std::condition_variable mWaitPoolEvents;
 
     class StartWorker: public Napi::AsyncWorker {
       public:


### PR DESCRIPTION
Now the code close the pollForEvents thread on destroy the NSFW object.
Also added a commit to be able to break (notify) the sleep in the pollForEvents thread, so we will not have to wait the debounceMs time on stopping the watcher or when we are destroying the NSFW object.