### PR TITLE
Windows free handle on access denied

### DIFF
--- a/includes/linux/InotifyTree.h
+++ b/includes/linux/InotifyTree.h
@@ -31,6 +31,7 @@ public:
   bool nodeExists(int wd);
   void removeDirectory(int wd);
   void renameDirectory(int fromWd, std::string fromName, int toWd, std::string toName);
+  bool existWatchedPath();
 
   ~InotifyTree();
 private:
@@ -96,6 +97,7 @@ private:
   std::map<int, InotifyNode *> *mInotifyNodeByWatchDescriptor;
   std::unordered_set<ino_t> inodes;
   InotifyNode *mRoot;
+  std::string mWatchedPath;
 
   friend class InotifyNode;
 };

--- a/includes/osx/FSEventsService.h
+++ b/includes/osx/FSEventsService.h
@@ -51,6 +51,7 @@ private:
   std::string mPath;
   RunLoop *mRunLoop;
   std::shared_ptr<EventQueue> mQueue;
+  bool mRootChanged;
 };
 
 #endif

--- a/includes/win32/Controller.h
+++ b/includes/win32/Controller.h
@@ -18,9 +18,6 @@ class Controller {
     ~Controller();
   private:
     std::unique_ptr<Watcher> mWatcher;
-
-    HANDLE openDirectory(const std::wstring &path);
-    HANDLE mDirectoryHandle;
 };
 
 #endif

--- a/includes/win32/Watcher.h
+++ b/includes/win32/Watcher.h
@@ -18,7 +18,7 @@ class Watcher
     ~Watcher();
 
     bool isRunning() const { return mRunning; }
-    std::string getError() const;
+    std::string getError();
 
   private:
     void run();
@@ -34,11 +34,15 @@ class Watcher
 
     std::string getUTF8Directory(std::wstring path) ;
 
+    std::wstring Watcher::getWatchedPath();
+    void Watcher::checkWatchedPath();
+
     std::atomic<bool> mRunning;
     SingleshotSemaphore mHasStartedSemaphore;
     SingleshotSemaphore mIsRunningSemaphore;
     mutable std::mutex mErrorMutex;
     std::string mError;
+    std::wstring mWatchedPath;
 
     const std::wstring mPath;
     std::shared_ptr<EventQueue> mQueue;

--- a/includes/win32/Watcher.h
+++ b/includes/win32/Watcher.h
@@ -14,7 +14,7 @@
 class Watcher
 {
   public:
-    Watcher(std::shared_ptr<EventQueue> queue, HANDLE dirHandle, const std::wstring &path, bool pathWasNtPrefixed);
+    Watcher(std::shared_ptr<EventQueue> queue, const std::wstring &path, bool pathWasNtPrefixed);
     ~Watcher();
 
     bool isRunning() const { return mRunning; }
@@ -29,18 +29,21 @@ class Watcher
     void setError(const std::string &error);
     void eventCallback(DWORD errorCode);
     void handleEvents();
+    void reopenWathedFolder();
+    HANDLE openDirectory(const std::wstring &path);
 
     void resizeBuffers(std::size_t size);
 
     std::string getUTF8Directory(std::wstring path) ;
 
-    std::wstring Watcher::getWatchedPath();
+    std::wstring Watcher::getWatchedPathFromHandle();
     void Watcher::checkWatchedPath();
 
     std::atomic<bool> mRunning;
     SingleshotSemaphore mHasStartedSemaphore;
     SingleshotSemaphore mIsRunningSemaphore;
     mutable std::mutex mErrorMutex;
+    mutable std::mutex mHandleMutex;
     std::string mError;
     std::wstring mWatchedPath;
 

--- a/src/linux/InotifyEventLoop.cpp
+++ b/src/linux/InotifyEventLoop.cpp
@@ -108,10 +108,6 @@ void InotifyEventLoop::work() {
       isDirectoryRemoval = event->mask & (uint32_t)(IN_IGNORED | IN_DELETE_SELF);
       isDirectoryEvent = event->mask & (uint32_t)(IN_ISDIR);
 
-      if (!isDirectoryRemoval && *event->name <= 31) {
-        continue;
-      }
-
       if (event->mask & (uint32_t)(IN_ATTRIB | IN_MODIFY)) {
         modify();
       } else if (event->mask & (uint32_t)IN_CREATE) {
@@ -133,7 +129,6 @@ void InotifyEventLoop::work() {
 
         renameStart();
       } else if (event->mask & (uint32_t)IN_MOVE_SELF) {
-        inotifyService->remove(event->wd, event->name);
         inotifyService->removeDirectory(event->wd);
       }
     } while((position += sizeof(struct inotify_event) + event->len) < bytesRead);

--- a/src/linux/InotifyService.cpp
+++ b/src/linux/InotifyService.cpp
@@ -58,12 +58,12 @@ void InotifyService::dispatchRename(int fromWd, std::string fromName, int toWd, 
 }
 
 std::string InotifyService::getError() {
-  if (!isWatching()) {
-    return "Service shutdown unexpectedly";
+  if (mTree != NULL && mTree->hasErrored()) {
+    return mTree->getError();
   }
 
-  if (mTree->hasErrored()) {
-    return mTree->getError();
+  if (!isWatching()) {
+    return "Service shutdown unexpectedly";
   }
 
   return "";

--- a/src/linux/InotifyTree.cpp
+++ b/src/linux/InotifyTree.cpp
@@ -78,10 +78,10 @@ bool InotifyTree::getPath(std::string &out, int wd) {
 }
 
 bool InotifyTree::hasErrored() {
-  if (!existWatchedPath()) {
+  if (mError.empty() && !existWatchedPath()) {
     mError = "Service shutdown: root path changed (renamed or deleted)";
   }
-  return mError != "";
+  return !mError.empty();
 }
 
 bool InotifyTree::isRootAlive() {

--- a/src/linux/InotifyTree.cpp
+++ b/src/linux/InotifyTree.cpp
@@ -19,8 +19,10 @@ InotifyTree::InotifyTree(int inotifyInstance, std::string path):
     watchName = path.substr(location + 1);
   }
 
+  mWatchedPath = directory + "/" + watchName;
+
   struct stat file;
-  if (stat((directory + "/" + watchName).c_str(), &file) < 0) {
+  if (stat(mWatchedPath.c_str(), &file) < 0) {
     mRoot = NULL;
     return;
   }
@@ -40,6 +42,11 @@ InotifyTree::InotifyTree(int inotifyInstance, std::string path):
     mRoot = NULL;
     return;
   }
+}
+
+bool InotifyTree::existWatchedPath() {
+  struct stat file;
+  return stat(mWatchedPath.c_str(), &file) >= 0;
 }
 
 void InotifyTree::addDirectory(int wd, std::string name, EmitCreatedEvent emitCreatedEvent) {
@@ -71,6 +78,9 @@ bool InotifyTree::getPath(std::string &out, int wd) {
 }
 
 bool InotifyTree::hasErrored() {
+  if (!existWatchedPath()) {
+    mError = "Service shutdown: root path changed (renamed or deleted)";
+  }
   return mError != "";
 }
 
@@ -94,6 +104,7 @@ void InotifyTree::removeDirectory(int wd) {
   if (parent == NULL) {
     delete mRoot;
     mRoot = NULL;
+    setError("Service shutdown: root path changed (renamed or deleted)");
     return;
   }
 

--- a/src/osx/RunLoop.cpp
+++ b/src/osx/RunLoop.cpp
@@ -56,7 +56,7 @@ void RunLoop::work() {
     pathsToWatch,
     kFSEventStreamEventIdSinceNow,
     latency,
-    kFSEventStreamCreateFlagFileEvents
+    kFSEventStreamCreateFlagFileEvents | kFSEventStreamCreateFlagWatchRoot
   );
 
   FSEventStreamScheduleWithRunLoop(mEventStream, mRunLoop, kCFRunLoopDefaultMode);

--- a/src/win32/Controller.cpp
+++ b/src/win32/Controller.cpp
@@ -1,4 +1,4 @@
-#include "../includes/win32/Controller.h"
+#include "../../includes/win32/Controller.h"
 
 static bool isNtPath(const std::wstring &path) {
   return path.rfind(L"\\\\?\\", 0) == 0 || path.rfind(L"\\??\\", 0) == 0;

--- a/src/win32/Watcher.cpp
+++ b/src/win32/Watcher.cpp
@@ -285,6 +285,13 @@ std::string Watcher::getError() {
     return "Failed to start watcher";
   }
 
+  {
+    std::lock_guard<std::mutex> lock(mErrorMutex);
+    if (!mError.empty()) {
+      return mError;
+    }
+  }
+
   checkWatchedPath();
 
   std::lock_guard<std::mutex> lock(mErrorMutex);

--- a/src/win32/Watcher.cpp
+++ b/src/win32/Watcher.cpp
@@ -1,4 +1,4 @@
-#include "../includes/win32/Watcher.h"
+#include "../../includes/win32/Watcher.h"
 
 #include <sstream>
 
@@ -114,6 +114,7 @@ Watcher::Watcher(std::shared_ptr<EventQueue> queue, HANDLE dirHandle, const std:
   ZeroMemory(&mOverlapped, sizeof(OVERLAPPED));
   mOverlapped.hEvent = this;
   resizeBuffers(1024 * 1024);
+  mWatchedPath = getWatchedPath();
   start();
 }
 
@@ -177,6 +178,8 @@ void Watcher::eventCallback(DWORD errorCode) {
       if (!pollDirectoryChanges()) {
         setError("failed resizing buffers for network traffic");
       }
+    } else if (errorCode == ERROR_ACCESS_DENIED) {
+      pollDirectoryChanges();
     } else {
       setError("Service shutdown unexpectedly");
     }
@@ -277,11 +280,40 @@ void Watcher::setError(const std::string &error) {
   mError = error;
 }
 
-std::string Watcher::getError() const {
+std::string Watcher::getError() {
   if (!isRunning()) {
     return "Failed to start watcher";
   }
 
+  checkWatchedPath();
+
   std::lock_guard<std::mutex> lock(mErrorMutex);
   return mError;
+}
+
+std::wstring Watcher::getWatchedPath() {
+  DWORD pathLen = GetFinalPathNameByHandleW(mDirectoryHandle, NULL, 0, VOLUME_NAME_NT);
+  if (pathLen == 0) {
+    setError("Service shutdown: root path changed (renamed or deleted)");
+    return NULL;
+  }
+
+  WCHAR* path = new WCHAR[pathLen];
+
+  if (GetFinalPathNameByHandleW(mDirectoryHandle, path, pathLen, VOLUME_NAME_NT) != pathLen - 1) {
+    setError("Service shutdown: root path changed (renamed or deleted)");
+    delete[] path;
+    return NULL;
+  }
+
+  std::wstring res(path);
+  delete[] path;
+  return res;
+}
+
+void Watcher::checkWatchedPath() {
+  std::wstring path = getWatchedPath();
+  if (!path.empty() && path.compare(mWatchedPath) != 0) {
+    setError("Service shutdown: root path changed (renamed or deleted)");
+  }
 }


### PR DESCRIPTION
Access denied can happen when we try to delete the watched folder in windows
In windows server 2019 the folder is not removed until folder handler is released
So the code will reopen the watched folder to release the handler and it will try to open it again
