### PR TITLE
Fix infinite loop watching large project on Linux

### DIFF
--- a/src/linux/InotifyTree.cpp
+++ b/src/linux/InotifyTree.cpp
@@ -314,7 +314,8 @@ InotifyTree::InotifyNode::InotifyNode(
 
     if (
       stat(filePath.c_str(), &file) < 0 ||
-      !S_ISDIR(file.st_mode)
+      !S_ISDIR(file.st_mode) ||
+      mTree->inodes.find(file.st_ino) != mTree->inodes.end() // avoid redundancy InotifyNode initialization
     ) {
       continue;
     }


### PR DESCRIPTION
## Fix infinite loop watching large project on Linux

Hello! I am retrox, a contributor of [OpenSumi Project](https://github.com/opensumi/core) (an open source IDE project like Eclipse Theia), dev team for Alibaba.inc , and we also use nsfw as the file watch framework. But these days I meet a problem, files cannot be watched when project is vert large, and sometimes block the whole ide process.
Then I found what cause this problem and open this pull request for bug fix.

My Problem See issue: #164 

## What caused this bug?  
see this commit: https://github.com/Axosoft/nsfw/commit/6ede292d61e47e628377b055e04f9dea87596311

INotifyTree.cpp
<img width="970" alt="image" src="https://user-images.githubusercontent.com/12879047/173571799-2f1ae594-da8d-4d51-9062-208c41faae59.png">

version 2.2.0:
check iNodes exists by `addInode` , if not exists then create new `InotifyNode`, if exists _not create_  `InotifyNode`

but at version 2.2.1:
create new `InotifyNode` and then check iNodes exists, if not exists, delete `InotifyNode`, and release memory.
so  `InotifyNode` will _always be created_ whether iNodes exists or not

it seems ok when project is not very large, because the number of files and folders are not very huge.

But the problem occurs when there are many files and folders.
Because Linux INotify resource is still wasted.

## Problem Detail
The problem is when folders and files nesting  is very complexed and number is very huge.
Just like this in my project:
<img width="599" alt="image" src="https://user-images.githubusercontent.com/12879047/173573414-b221d56a-d83e-4505-b4df-0803751be064.png">

when nsfw is watching this project, I dump the files InotifyNode created and then deleted, just like this:

<img width="700" alt="image" src="https://user-images.githubusercontent.com/12879047/173575269-05543af4-4221-404d-8094-b2b750c8bb1b.png">

the result is very shocking: the redundancy nodes are over 60000 until i force close the watch process, if I didn't the number will be much larger... I don't when will this loop end.
<img width="645" alt="image" src="https://user-images.githubusercontent.com/12879047/173575473-b8defa45-fa1b-4e97-bd41-3a2be9c4967c.png">
(in this screenshot i use file handler instead of path)

## My Fix of this Problem
after checking logs and previous commit history, I write the code of avoid redundancy InotifyNode initialization before new InotifyNode created by use std map find `file.st_ino` exists or not. Just like what v2.2.0 do.

so no more redundancy InotifyNode will be created and linux inotify resources are saved.


## Compare
before fix: (run after 5 mins)
<img width="833" alt="image" src="https://user-images.githubusercontent.com/12879047/173577248-683890f3-2cf8-48a5-b09b-11e89111d9de.png">
and sometimes high cpu usage:
<img width="664" alt="image" src="https://user-images.githubusercontent.com/12879047/173579974-bb43584f-4122-42fb-b111-e366913873f6.png">

after fix:
<img width="494" alt="image" src="https://user-images.githubusercontent.com/12879047/173577308-decb28c0-8ac1-4bb5-be15-305a06d29b3e.png">

## Check Log or Reproduce
see Issue for reproduce:  #164 
check logs i used for debug: the repo i forked and branch nsfw-debug-retrox
 https://github.com/life2015/nsfw/tree/nsfw-debug-retrox
