### PR TITLE
Fix crash on exit.

### DIFF
--- a/includes/NSFW.h
+++ b/includes/NSFW.h
@@ -13,7 +13,6 @@
 
 class NSFW : public Napi::ObjectWrap<NSFW> {
   private:
-    static Napi::FunctionReference constructor;
     Napi::Value ExcludedPaths();
     static std::size_t instanceCount;
     static bool gcEnabled;
@@ -32,6 +31,8 @@ class NSFW : public Napi::ObjectWrap<NSFW> {
     std::mutex mRunningLock;
     std::vector<std::string> mExcludedPaths;
     void updateExcludedPaths();
+
+    static void cleanup(void* arg);
 
     class StartWorker: public Napi::AsyncWorker {
       public:
@@ -131,7 +132,6 @@ class NSFW : public Napi::ObjectWrap<NSFW> {
     void resumeQueue();
     void pollForEvents();
 
-    void Finalize(Napi::Env env);
     NSFW(const Napi::CallbackInfo &info);
     ~NSFW();
 };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "homepage": "https://github.com/axosoft/node-simple-file-watcher",
   "dependencies": {
-    "node-addon-api": "*"
+    "node-addon-api": "^5.0.0"
   },
   "devDependencies": {
     "eslint": "^6.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -920,10 +920,10 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-addon-api@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.1.0.tgz#98b21931557466c6729e51cb77cd39c965f42239"
-  integrity sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw==
+node-addon-api@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.0.0.tgz#7d7e6f9ef89043befdb20c1989c905ebde18c501"
+  integrity sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA==
 
 node-environment-flags@1.0.6:
   version "1.0.6"


### PR DESCRIPTION
In electron 17 when Finalize function is called node has cleaned the internal ref, so we do not have to call Unref, but we need to call Unref in electron 13 to avoid segfault.
Now we will use `AddCleanupHook` to clean the ref.

This should fix #157