### PR TITLE
Fix mtx_do_lock on exit or reload context

### DIFF
--- a/includes/NSFW.h
+++ b/includes/NSFW.h
@@ -32,8 +32,6 @@ class NSFW : public Napi::ObjectWrap<NSFW> {
     std::vector<std::string> mExcludedPaths;
     void updateExcludedPaths();
 
-    static void cleanup(void* arg);
-
     class StartWorker: public Napi::AsyncWorker {
       public:
         StartWorker(Napi::Env env, NSFW *nsfw);

--- a/js/spec/worker.js
+++ b/js/spec/worker.js
@@ -1,0 +1,78 @@
+const {
+  isMainThread,
+  parentPort,
+  workerData
+} = require('worker_threads');
+
+const nsfw = require('../src');
+
+if (isMainThread) {
+  throw new Error('Must be run via worker thread');
+}
+
+
+const { workDir, test } = workerData;
+
+// aggressively collects garbage until we fail to improve terminatingIteration times.
+function garbageCollect() {
+  const terminatingIterations = 3;
+  let usedBeforeGC = Number.MAX_VALUE;
+  let nondecreasingIterations = 0;
+  for (; ;) {
+    global.gc();
+    const usedAfterGC = process.memoryUsage().heapUsed;
+    if (usedAfterGC >= usedBeforeGC) {
+      nondecreasingIterations++;
+      if (nondecreasingIterations >= terminatingIterations) {
+        break;
+      }
+    }
+    usedBeforeGC = usedAfterGC;
+  }
+}
+
+
+parentPort.postMessage('init');
+
+const runTest1 = async () => {
+  const watch = await nsfw(
+    workDir,
+    () => {}
+  );
+  await watch.start();
+  parentPort.postMessage('success');
+};
+
+
+const runTest2 = async () => {
+  const watch1 = await nsfw(
+    workDir,
+    () => {}
+  );
+  await watch1.start();
+
+  const watch2 = await nsfw(
+    workDir,
+    () => {}
+  );
+  await watch2.start();
+
+  let watch3 = await nsfw(
+    workDir,
+    () => {}
+  );
+  await watch3.start();
+  await watch3.stop();
+  watch3 = null;
+  garbageCollect();
+  parentPort.postMessage('success');
+};
+
+switch(test) {
+  case 1:
+    runTest1().then(() => {});
+    break;
+  case 2:
+    runTest2().then(() => {});
+    break;
+}

--- a/src/win32/Watcher.cpp
+++ b/src/win32/Watcher.cpp
@@ -190,8 +190,8 @@ HANDLE Watcher::openDirectory(const std::wstring &path) {
 }
 
 void Watcher::reopenWathedFolder() {
-  std::lock_guard<std::mutex> lock(mHandleMutex);
   {
+    std::lock_guard<std::mutex> lock(mHandleMutex);
     CancelIo(mDirectoryHandle);
     CloseHandle(mDirectoryHandle);
     mDirectoryHandle = openDirectory(mPath);


### PR DESCRIPTION
We made an effort to try using AddCleanupHook to stop the watcher on all NSFW instances when exiting from a worker or electron context, but in the end we couldn’t make it work correctly, so we had to stop using them.
The reason is that using CleanupHooks introduces a problem: if you create and free a NSFW object when you close o reload a context or worker the CleanupHook will be triggered on an already freed object, so you will get a crash. We have tried to remove the  CleanupHook before that, but you will get a crash if you try to remove it in the destructor. You cannot create or remove a CleanupHook anywhere you want, you can only do it when you have access to Napi::env directly in the call, and you cannot store it to use it later in the destructor.
