### PR TITLE
Linux: Add support for fanotify when available (running as root)

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -66,9 +66,13 @@
                     "NSFW_TEST_SLOW_<!(node -p process.env.NSFW_TEST_SLOW)"
                 ],
                 "sources": [
+                    "src/linux/FanotifyEventLoop.cpp",
+                    "src/linux/FanotifyTree.cpp",
+                    "src/linux/FanotifyService.cpp",
                     "src/linux/InotifyEventLoop.cpp",
                     "src/linux/InotifyTree.cpp",
-                    "src/linux/InotifyService.cpp"
+                    "src/linux/InotifyService.cpp",
+                    "src/linux/NotifyService.cpp"
                 ],
                 "cflags": [
                     "-Wno-unknown-pragmas",

--- a/includes/NativeInterface.h
+++ b/includes/NativeInterface.h
@@ -8,8 +8,8 @@ using NativeImplementation = Controller;
 #include "../includes/osx/FSEventsService.h"
 using NativeImplementation = FSEventsService;
 #elif defined(__linux__) || defined(__FreeBSD__)
-#include "../includes/linux/InotifyService.h"
-using NativeImplementation = InotifyService;
+#include "../includes/linux/NotifyService.h"
+using NativeImplementation = NotifyService;
 #endif
 
 #include "Queue.h"

--- a/includes/linux/FanotifyEventLoop.h
+++ b/includes/linux/FanotifyEventLoop.h
@@ -1,0 +1,45 @@
+#ifndef FANOTIFY_EVENT_LOOP_H
+#define FANOTIFY_EVENT_LOOP_H
+
+#include "FanotifyService.h"
+#include "../SingleshotSemaphore.h"
+
+#include <sys/fanotify.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string>
+#include <mutex>
+
+class FanotifyService;
+class Lock;
+
+class FanotifyEventLoop {
+public:
+  FanotifyEventLoop(
+    int fanotifyInstance,
+    FanotifyService *inotifyService
+  );
+
+  bool isLooping();
+
+  void work();
+
+  ~FanotifyEventLoop();
+private:
+  static const int BUFFER_SIZE = 8192;
+  struct FanotifyRenameEvent {
+    bool isStarted;
+    std::string name;
+    int fd;
+  };
+
+  int mFanotifyInstance;
+  FanotifyService *mFanotifyService;
+
+  pthread_t mEventLoop;
+  std::mutex mMutex;
+  SingleshotSemaphore mLoopingSemaphore;
+  bool mStarted;
+};
+
+#endif

--- a/includes/linux/FanotifyService.h
+++ b/includes/linux/FanotifyService.h
@@ -1,24 +1,24 @@
-#ifndef INOTIFY_EVENT_HANDLER_H
-#define INOTIFY_EVENT_HANDLER_H
+#ifndef FANOTIFY_EVENT_HANDLER_H
+#define FANOTIFY_EVENT_HANDLER_H
 
-#include "InotifyEventLoop.h"
-#include "InotifyTree.h"
+#include "FanotifyEventLoop.h"
+#include "FanotifyTree.h"
 #include "../Queue.h"
 #include <queue>
 
-class InotifyEventLoop;
-class InotifyTree;
+class FanotifyEventLoop;
+class FanotifyTree;
 
-class InotifyService {
+class FanotifyService {
 public:
-  InotifyService(std::shared_ptr<EventQueue> queue, std::string path, const std::vector<std::string> &excludedPaths);
+  FanotifyService(std::shared_ptr<EventQueue> queue, std::string path, const std::vector<std::string> &excludedPaths);
 
   std::string getError();
   bool hasErrored();
   bool isWatching();
   void updateExcludedPaths(const std::vector<std::string> &excludedPaths);
 
-  ~InotifyService();
+  ~FanotifyService();
 private:
   void create(int wd, std::string name);
   void createDirectory(int wd, std::string name);
@@ -27,16 +27,14 @@ private:
   void dispatchRename(int fromWd, std::string fromName, int toWd, std::string toName);
   void modify(int wd, std::string name);
   void remove(int wd, std::string name);
-  void removeDirectory(int wd);
   void rename(int fromWd, std::string fromName, int toWd, std::string toName);
-  void renameDirectory(int fromWd, std::string fromName, int toWd, std::string toName);
 
-  InotifyEventLoop *mEventLoop;
+  FanotifyEventLoop *mEventLoop;
   std::shared_ptr<EventQueue> mQueue;
-  InotifyTree *mTree;
-  int mInotifyInstance;
+  FanotifyTree *mTree;
+  int mFanotifyInstance;
 
-  friend class InotifyEventLoop;
+  friend class FanotifyEventLoop;
 };
 
 #endif

--- a/includes/linux/FanotifyTree.h
+++ b/includes/linux/FanotifyTree.h
@@ -1,6 +1,7 @@
 #ifndef FANOTIFY_TREE_H
 #define FANOTIFY_TREE_H
 #include <sys/fanotify.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #include <dirent.h>
 #include <stdlib.h>
@@ -16,12 +17,17 @@ public:
   bool getPath(std::string &out, int wd);
   const std::vector<std::string>& getExcludedPaths() const;
   void updateExcludedPaths(const std::vector<std::string> &excludedPaths);
+  std::string getError();
+  bool hasErrored();
 
   ~FanotifyTree();
 private:
+  bool existWatchedPath();
+  
   const int mFanotifyInstance;
   std::vector<std::string> mExcludedPaths;
   std::string mPath;
+  std::string mError;
 };
 
 #endif

--- a/includes/linux/FanotifyTree.h
+++ b/includes/linux/FanotifyTree.h
@@ -1,0 +1,27 @@
+#ifndef FANOTIFY_TREE_H
+#define FANOTIFY_TREE_H
+#include <sys/fanotify.h>
+#include <unistd.h>
+#include <dirent.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <string>
+#include <vector>
+#include <functional>
+
+class FanotifyTree {
+public:
+  FanotifyTree(int fanotifyInstance, std::string path, const std::vector<std::string> &excludedPaths);
+
+  bool getPath(std::string &out, int wd);
+  const std::vector<std::string>& getExcludedPaths() const;
+  void updateExcludedPaths(const std::vector<std::string> &excludedPaths);
+
+  ~FanotifyTree();
+private:
+  const int mFanotifyInstance;
+  std::vector<std::string> mExcludedPaths;
+  std::string mPath;
+};
+
+#endif

--- a/includes/linux/FanotifyTree.h
+++ b/includes/linux/FanotifyTree.h
@@ -9,6 +9,8 @@
 #include <string>
 #include <vector>
 #include <functional>
+#include <chrono>
+#include <thread>
 
 class FanotifyTree {
 public:
@@ -23,7 +25,7 @@ public:
   ~FanotifyTree();
 private:
   bool existWatchedPath();
-  
+
   const int mFanotifyInstance;
   std::vector<std::string> mExcludedPaths;
   std::string mPath;

--- a/includes/linux/NotifyService.h
+++ b/includes/linux/NotifyService.h
@@ -1,0 +1,31 @@
+#ifndef NOTIFY_EVENT_HANDLER_H
+#define NOTIFY_EVENT_HANDLER_H
+
+#include "InotifyService.h"
+#include "FanotifyService.h"
+#include "../Queue.h"
+#include <queue>
+#include <map>
+
+class InotifyService;
+class FanotifyService;
+
+class NotifyService {
+public:
+  NotifyService(std::shared_ptr<EventQueue> queue, std::string path, const std::vector<std::string> &excludedPaths);
+
+  std::string getError();
+  bool hasErrored();
+  bool isWatching();
+  void updateExcludedPaths(const std::vector<std::string> &excludedPaths);
+
+  ~NotifyService();
+private:
+  InotifyService *mInotifyService;
+  FanotifyService *mFanotifyService;
+
+  friend class InotifyService;
+  friend class FanotifyService;
+};
+
+#endif

--- a/includes/linux/NotifyService.h
+++ b/includes/linux/NotifyService.h
@@ -5,10 +5,6 @@
 #include "FanotifyService.h"
 #include "../Queue.h"
 #include <queue>
-#include <map>
-
-class InotifyService;
-class FanotifyService;
 
 class NotifyService {
 public:
@@ -23,9 +19,6 @@ public:
 private:
   InotifyService *mInotifyService;
   FanotifyService *mFanotifyService;
-
-  friend class InotifyService;
-  friend class FanotifyService;
 };
 
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,9 +22,13 @@ if (UNIX)
     else (APPLE)
         message (STATUS "compiling linux specific file system service")
         set (NSFW_LIBRARY_SOURCES ${NSFW_LIBRARY_SOURCES}
+            linux/FanotifyEventLoop.cpp
+            linux/FanotifyService.cpp
+            linux/FanotifyTree.cpp
             linux/InotifyEventLoop.cpp
             linux/InotifyService.cpp
             linux/InotifyTree.cpp
+            linux/NotifyService.cpp
         )
     endif(APPLE)
 endif (UNIX)

--- a/src/linux/FanotifyEventLoop.cpp
+++ b/src/linux/FanotifyEventLoop.cpp
@@ -1,0 +1,100 @@
+#include "../../includes/linux/FanotifyEventLoop.h"
+
+FanotifyEventLoop::FanotifyEventLoop(
+  int fanotifyInstance,
+  FanotifyService *fanotifyService
+) :
+  mFanotifyInstance(fanotifyInstance),
+  mFanotifyService(fanotifyService)
+{
+  mStarted = !pthread_create(
+    &mEventLoop,
+    NULL,
+    [](void *eventLoop)->void * {
+      ((FanotifyEventLoop *)eventLoop)->work();
+      return NULL;
+    },
+    (void *)this
+  );
+    if (mStarted) { mLoopingSemaphore.wait(); }
+}
+
+bool FanotifyEventLoop::isLooping() {
+  return mStarted;
+}
+
+void FanotifyEventLoop::work() {
+  char buffer[BUFFER_SIZE];
+  char *pathname;
+  fanotify_event_metadata *event = NULL;
+  unsigned int bytesRead;
+  FanotifyService *fanotifyService = mFanotifyService;
+  FanotifyRenameEvent renameEvent;
+  renameEvent.isStarted = false;
+
+  mLoopingSemaphore.signal();
+  while((bytesRead = read(mFanotifyInstance, &buffer, BUFFER_SIZE)) > 0) {
+    std::lock_guard<std::mutex> syncWithDestructor(mMutex);
+    for (event = (struct fanotify_event_metadata *) buffer;
+        FAN_EVENT_OK(event, bytesRead);
+        event = FAN_EVENT_NEXT(event, bytesRead)) {
+      struct fanotify_event_info_fid *fid = (struct fanotify_event_info_fid *) (event + 1);
+      struct file_handle *file_handle = (struct file_handle *)fid->handle;
+
+      if (fid->hdr.info_type == FAN_EVENT_INFO_TYPE_DFID_NAME) {
+        pathname = (char *)file_handle->f_handle + file_handle->handle_bytes;
+      } else {
+        continue;
+      }
+
+      int event_fd = open_by_handle_at(AT_FDCWD, file_handle, O_RDONLY);
+      if (event_fd == -1) {
+        continue;
+      }
+
+      if (event->mask & (uint32_t)(FAN_ATTRIB | FAN_MODIFY)) {
+        fanotifyService->modify(event_fd, pathname);
+      } else if (event->mask & (uint32_t)FAN_CREATE) {
+        fanotifyService->create(event_fd, pathname);
+      } else if (event->mask & (uint32_t)(FAN_DELETE | FAN_DELETE_SELF)) {
+        fanotifyService->remove(event_fd, pathname);
+      } else if (event->mask & (uint32_t)FAN_MOVED_TO) {
+        if (!renameEvent.isStarted) {
+          fanotifyService->create(event_fd, pathname);
+          close(event_fd);
+          continue;
+        }
+
+        fanotifyService->rename(renameEvent.fd, renameEvent.name, event_fd, pathname);
+        close(renameEvent.fd);
+        renameEvent.isStarted = false;
+      } else if (event->mask & (uint32_t)FAN_MOVED_FROM) {
+        renameEvent.name = pathname;
+        renameEvent.fd = event_fd;
+        renameEvent.isStarted = true;
+        continue;
+      }
+
+      close(event_fd);
+    }
+
+    if (renameEvent.isStarted) {
+      fanotifyService->remove(renameEvent.fd, renameEvent.name);
+      renameEvent.isStarted = false;
+    }
+  }
+  mStarted = false;
+}
+
+FanotifyEventLoop::~FanotifyEventLoop() {
+  if (!mStarted) {
+    return;
+  }
+
+  {
+    std::lock_guard<std::mutex> syncWithWork(mMutex);
+    pthread_cancel(mEventLoop);
+  }
+
+  pthread_join(mEventLoop, NULL);
+}

--- a/src/linux/FanotifyService.cpp
+++ b/src/linux/FanotifyService.cpp
@@ -71,6 +71,10 @@ void FanotifyService::dispatchRename(int fromWd, std::string fromName, int toWd,
 }
 
 std::string FanotifyService::getError() {
+  if (mTree != NULL && mTree->hasErrored()) {
+    return mTree->getError();
+  }
+
   if (!isWatching()) {
     return "Service shutdown unexpectedly";
   }
@@ -79,7 +83,7 @@ std::string FanotifyService::getError() {
 }
 
 bool FanotifyService::hasErrored() {
-  return !isWatching();
+  return !isWatching() || (mTree == NULL ? false : mTree->hasErrored());
 }
 
 bool FanotifyService::isWatching() {

--- a/src/linux/FanotifyService.cpp
+++ b/src/linux/FanotifyService.cpp
@@ -1,0 +1,108 @@
+#include "../../includes/linux/FanotifyService.h"
+
+FanotifyService::FanotifyService(std::shared_ptr<EventQueue> queue, std::string path, const std::vector<std::string> &excludedPaths):
+  mEventLoop(NULL),
+  mQueue(queue),
+  mTree(NULL) {
+  
+  #ifdef FAN_REPORT_FID
+    mFanotifyInstance = fanotify_init(FAN_CLASS_NOTIF | FAN_REPORT_FID | FAN_REPORT_DIR_FID | FAN_REPORT_NAME, O_LARGEFILE);
+    
+    if (mFanotifyInstance >= 0) {
+      uint64_t mask = FAN_MODIFY | FAN_ATTRIB | FAN_CREATE | FAN_DELETE | FAN_MOVE | FAN_ONDIR;
+      int res = fanotify_mark(mFanotifyInstance, FAN_MARK_ADD | FAN_MARK_FILESYSTEM, mask, AT_FDCWD, path.c_str());
+
+      if (res >= 0) {
+        mEventLoop = new FanotifyEventLoop(
+          mFanotifyInstance,
+          this
+        );
+        mTree = new FanotifyTree(mFanotifyInstance, path, excludedPaths);
+        return;
+      }
+    }
+  #endif
+}
+
+FanotifyService::~FanotifyService() {
+  if (mEventLoop != NULL) {
+    delete mEventLoop;
+  }
+
+  if (mTree != NULL) {
+    delete mTree;
+  }
+
+  close(mFanotifyInstance);
+}
+
+void FanotifyService::create(int wd, std::string name) {
+  dispatch(CREATED, wd, name);
+}
+
+void FanotifyService::dispatch(EventType action, int wd, std::string name) {
+  std::string path;
+
+  if (mTree != NULL && !mTree->getPath(path, wd)) {
+    return;
+  }
+
+  mQueue->enqueue(action, path, name);
+}
+
+void FanotifyService::dispatchRename(int fromWd, std::string fromName, int toWd, std::string toName) {
+  std::string fromPath, toPath;
+
+  if (mTree != NULL) {
+    bool isFrom = mTree->getPath(fromPath, fromWd);
+    bool isTo = mTree->getPath(toPath, toWd);
+
+    if (!isFrom && !isTo) {
+      return;
+    } else if (!isFrom) {
+      mQueue->enqueue(CREATED, toPath, toName);
+      return;
+    } else if (!isTo) {
+      mQueue->enqueue(DELETED, fromPath, fromName);
+      return;
+    }
+  }
+
+  mQueue->enqueue(RENAMED, fromPath, fromName, toPath, toName);
+}
+
+std::string FanotifyService::getError() {
+  if (!isWatching()) {
+    return "Service shutdown unexpectedly";
+  }
+
+  return "";
+}
+
+bool FanotifyService::hasErrored() {
+  return !isWatching();
+}
+
+bool FanotifyService::isWatching() {
+  if (mEventLoop == NULL) {
+    return false;
+  }
+  
+  return mEventLoop->isLooping();
+}
+
+void FanotifyService::modify(int wd, std::string name) {
+  dispatch(MODIFIED, wd, name);
+}
+
+void FanotifyService::remove(int wd, std::string name) {
+  dispatch(DELETED, wd, name);
+}
+
+void FanotifyService::rename(int fromWd, std::string fromName, int toWd, std::string toName) {
+  dispatchRename(fromWd, fromName, toWd, toName);
+}
+
+void FanotifyService::updateExcludedPaths(const std::vector<std::string> &excludedPaths) {
+  mTree->updateExcludedPaths(excludedPaths);
+}

--- a/src/linux/FanotifyService.cpp
+++ b/src/linux/FanotifyService.cpp
@@ -18,7 +18,6 @@ FanotifyService::FanotifyService(std::shared_ptr<EventQueue> queue, std::string 
           this
         );
         mTree = new FanotifyTree(mFanotifyInstance, path, excludedPaths);
-        return;
       }
     }
   #endif

--- a/src/linux/FanotifyTree.cpp
+++ b/src/linux/FanotifyTree.cpp
@@ -1,0 +1,54 @@
+#include "../../includes/linux/FanotifyTree.h"
+#include <cstdio>
+#include <sys/stat.h>
+
+#include <algorithm>
+
+/**
+ * FanotifyTree ---------------------------------------------------------------------------------------------------------
+ */
+FanotifyTree::FanotifyTree(int fanotifyInstance, std::string path, const std::vector<std::string> &excludedPaths):
+  mFanotifyInstance(fanotifyInstance) {
+  std::string directory;
+  std::string watchName;
+  mExcludedPaths = excludedPaths;
+  if (path.back() == '/') {
+    mPath = path.substr(0, path.length() - 2);
+  } else {
+    mPath = path;
+  }
+}
+
+bool FanotifyTree::getPath(std::string &out, int wd) {
+  std::string fdPath = "/proc/self/fd/" + std::to_string(wd);
+  
+  char path[PATH_MAX];
+  ssize_t len = readlink(fdPath.c_str(), path, sizeof(path) - 1);
+
+  if (len != -1) {
+    path[len] = '\0';
+    out = std::string(path);
+  } else {
+    return false;
+  }
+
+  if (out.rfind(mPath, 0) != 0) {
+    return false;
+  }
+
+  for (auto excludedPath : mExcludedPaths) {
+    if (out.rfind(excludedPath, 0) == 0) {
+      return false;
+    }
+  }
+  
+  return true;
+}
+
+const std::vector<std::string>& FanotifyTree::getExcludedPaths() const {
+  return mExcludedPaths;
+}
+
+void FanotifyTree::updateExcludedPaths(const std::vector<std::string> &excludedPaths) {
+  mExcludedPaths = excludedPaths;
+}

--- a/src/linux/FanotifyTree.cpp
+++ b/src/linux/FanotifyTree.cpp
@@ -57,3 +57,19 @@ void FanotifyTree::updateExcludedPaths(const std::vector<std::string> &excludedP
 
 FanotifyTree::~FanotifyTree() {
 }
+
+bool FanotifyTree::existWatchedPath() {
+  struct stat file;
+  return stat(mPath.c_str(), &file) >= 0;
+}
+
+std::string FanotifyTree::getError() {
+  return mError;
+}
+
+bool FanotifyTree::hasErrored() {
+  if (mError.empty() && !existWatchedPath()) {
+    mError = "Service shutdown: root path changed (renamed or deleted)";
+  }
+  return !mError.empty();
+}

--- a/src/linux/FanotifyTree.cpp
+++ b/src/linux/FanotifyTree.cpp
@@ -9,8 +9,6 @@
  */
 FanotifyTree::FanotifyTree(int fanotifyInstance, std::string path, const std::vector<std::string> &excludedPaths):
   mFanotifyInstance(fanotifyInstance) {
-  std::string directory;
-  std::string watchName;
   mExcludedPaths = excludedPaths;
   if (path.back() == '/') {
     mPath = path.substr(0, path.length() - 2);
@@ -21,6 +19,10 @@ FanotifyTree::FanotifyTree(int fanotifyInstance, std::string path, const std::ve
 
 bool FanotifyTree::getPath(std::string &out, int wd) {
   std::string fdPath = "/proc/self/fd/" + std::to_string(wd);
+
+  #ifdef NSFW_TEST_SLOW_1
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  #endif
   
   char path[PATH_MAX];
   ssize_t len = readlink(fdPath.c_str(), path, sizeof(path) - 1);
@@ -51,4 +53,7 @@ const std::vector<std::string>& FanotifyTree::getExcludedPaths() const {
 
 void FanotifyTree::updateExcludedPaths(const std::vector<std::string> &excludedPaths) {
   mExcludedPaths = excludedPaths;
+}
+
+FanotifyTree::~FanotifyTree() {
 }

--- a/src/linux/NotifyService.cpp
+++ b/src/linux/NotifyService.cpp
@@ -1,0 +1,66 @@
+#include "../../includes/linux/NotifyService.h"
+
+NotifyService::NotifyService(std::shared_ptr<EventQueue> queue, std::string path, const std::vector<std::string> &excludedPaths) {
+  mFanotifyService = new FanotifyService(queue, path, excludedPaths);
+
+  if (!mFanotifyService->isWatching()) {
+    delete mFanotifyService;
+    mInotifyService = new InotifyService(queue, path, excludedPaths);
+  }
+}
+
+NotifyService::~NotifyService() {
+  if (mFanotifyService != NULL) {
+    delete mFanotifyService;
+  }
+
+  if (mInotifyService != NULL) {
+    delete mInotifyService;
+  }
+}
+
+std::string NotifyService::getError() {
+  if (mInotifyService != NULL) {
+    return mInotifyService->getError();
+  }
+
+  if (mFanotifyService != NULL) {
+    return mFanotifyService->getError();
+  }
+
+  return "";
+}
+
+bool NotifyService::hasErrored() {
+  if (mInotifyService != NULL) {
+    return mInotifyService->hasErrored();
+  }
+
+  if (mFanotifyService != NULL) {
+    return mFanotifyService->hasErrored();
+  }
+
+  return false;
+}
+
+bool NotifyService::isWatching() {
+  if (mInotifyService != NULL) {
+    return mInotifyService->isWatching();
+  }
+
+  if (mFanotifyService != NULL) {
+    return mFanotifyService->isWatching();
+  }
+
+  return false;
+}
+
+void NotifyService::updateExcludedPaths(const std::vector<std::string> &excludedPaths) {
+  if (mInotifyService != NULL) {
+    mInotifyService->updateExcludedPaths(excludedPaths);
+  }
+
+  if (mFanotifyService != NULL) {
+    mFanotifyService->updateExcludedPaths(excludedPaths);
+  }
+}

--- a/src/linux/NotifyService.cpp
+++ b/src/linux/NotifyService.cpp
@@ -1,10 +1,13 @@
 #include "../../includes/linux/NotifyService.h"
 
-NotifyService::NotifyService(std::shared_ptr<EventQueue> queue, std::string path, const std::vector<std::string> &excludedPaths) {
+NotifyService::NotifyService(std::shared_ptr<EventQueue> queue, std::string path, const std::vector<std::string> &excludedPaths):
+  mInotifyService(NULL),
+  mFanotifyService(NULL) {
   mFanotifyService = new FanotifyService(queue, path, excludedPaths);
 
   if (!mFanotifyService->isWatching()) {
     delete mFanotifyService;
+    mFanotifyService = NULL;
     mInotifyService = new InotifyService(queue, path, excludedPaths);
   }
 }


### PR DESCRIPTION
In theory, this should allow for a more efficient way to watch entire filesystems without hitting the watch limits on Linux. I've seen this requested a few times in unrelated issues (mostly VSCode). This only works when running as root.

Let me know if this is something you'd be interested integrating into your project. Lacks unit tests since I'm not sure if this is going to be the final implementation of this.