### PR TITLE
Removed illegal qualified name in member declaration on the Watcher.h file

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -29,7 +29,7 @@
                 ],
                 "msvs_settings": {
                     "VCCLCompilerTool": {
-                        "DisableSpecificWarnings": [ "4506", "4538", "4793", "4596" ]
+                        "DisableSpecificWarnings": [ "4506", "4538", "4793" ]
                     },
                     "VCLinkerTool": {
                         "AdditionalOptions": [ "/ignore:4248" ]

--- a/binding.gyp
+++ b/binding.gyp
@@ -29,7 +29,7 @@
                 ],
                 "msvs_settings": {
                     "VCCLCompilerTool": {
-                        "DisableSpecificWarnings": [ "4506", "4538", "4793" ]
+                        "DisableSpecificWarnings": [ "4506", "4538", "4793", "4596" ]
                     },
                     "VCLinkerTool": {
                         "AdditionalOptions": [ "/ignore:4248" ]

--- a/includes/win32/Watcher.h
+++ b/includes/win32/Watcher.h
@@ -37,10 +37,10 @@ class Watcher
     void resizeBuffers(std::size_t size);
 
     std::string getUTF8Directory(std::wstring path) ;
-    bool Watcher::isExcluded(const std::wstring &fileName);
+    bool isExcluded(const std::wstring &fileName);
 
-    std::wstring Watcher::getWatchedPathFromHandle();
-    void Watcher::checkWatchedPath();
+    std::wstring getWatchedPathFromHandle();
+    void checkWatchedPath();
 
     std::atomic<bool> mRunning;
     SingleshotSemaphore mHasStartedSemaphore;


### PR DESCRIPTION
Removed the illegal qualified name in member declaration on the Watcher.h so that we can install nsfw on node 22.
Closes #181 