### PR TITLE
Swallow exceptions in terminating environments…

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,7 +1,9 @@
 {
     "targets": [{
         "target_name": "nsfw",
-
+        "defines": [
+            "NODE_API_SWALLOW_UNTHROWABLE_EXCEPTIONS"
+        ],
         "sources": [
             "src/NSFW.cpp",
             "src/Queue.cpp",


### PR DESCRIPTION
…triggered by `nsfw` async operations.

This fixes #184 and is a product of the discussion in that issue.

There appears to be an exception caused by the following chain of events:

* NSFW loaded in a worker thread or other context-aware environment
* `start` called on an NSFW instance, returning a promise
* environment terminated (via `worker.terminate()` or the equivalent
* the `start` promise resolves

Ordinarily, [this is a fatal error](https://github.com/nodejs/node-addon-api/blob/main/doc/setup.md):

> By default, throwing an exception on a terminating environment (eg. worker threads) will cause a fatal exception, terminating the Node process. This is to provide feedback to the user of the runtime error, as it is impossible to pass the error to JavaScript when the environment is terminating.

`NODE_API_SWALLOW_UNTHROWABLE_EXCEPTIONS` was created to enable a mode where such exceptions are caught and swallowed so that they don't bring the entire process down.

This [test in N-API itself](https://github.com/nodejs/node-addon-api/blob/82e881c3b22a5365b4d87b043e7cb76e9ca208dd/test/error_terminating_environment.js#L73-L74) may be useful to consult: it creates a worker, start an async operation, terminates the worker, then triggers an exception from the C++ code. The two “swallow exceptions” modes are the only ones in which the process is meant to keep going after such a failure.

I need this in an Electron environment — specifically loading `nsfw` in a renderer process, where a simple page reload is enough to create a terminating environment like the one in that test case.