### PR TITLE
🐛 fix hanging shutdown

### DIFF
--- a/includes/NSFW.h
+++ b/includes/NSFW.h
@@ -122,6 +122,7 @@ class NSFW : public Napi::ObjectWrap<NSFW> {
     };
 
     Napi::Value UpdateExcludedPaths(const Napi::CallbackInfo &info);
+    Napi::Value Close(const Napi::CallbackInfo &info);
 
   public:
     static Napi::Object Init(Napi::Env, Napi::Object exports);

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -48,6 +48,7 @@ function NSFWFilePoller(watchPath, eventCallback, debounceMS) {
 
   this.pause = () => this.stop();
   this.resume = () => this.start();
+  this.close = () => this.close();
 }
 
 
@@ -112,6 +113,7 @@ function nsfw(watchPath, eventCallback, options) {
   this.resume = () => implementation.resume();
   this.getExcludedPaths = () => implementation.getExcludedPaths();
   this.updateExcludedPaths = (paths) => implementation.updateExcludedPaths(paths);
+  this.close = () => implementation.close();
 }
 
 


### PR DESCRIPTION
possible fix for #187 

The problem - as I understand it - seems to be that the callbacks are used in multiple threads.

First the constructor has the event and error callback as argument.

This is - as far as I understand it - the main thread. The initial usage count for this thread is 1.

Then at some point a watcher is started and the callback is actually used for the first time. This is done in a separate thread it seems.

https://github.com/nodejs/node-addon-api/blob/main/doc/threadsafe_function.md#acquire indicates that it tracks the usage per thread but a bit unclear to me.

So the worker threads acquire the functions and register that another thread is using them.

now when the script in the bug report executes nodejs has to think in the end that the mainthread is still using the callback and will not call the destructor of the object because there is no connection between the stop() function and the object itself. It might possibly be restarted again.

I added a super helpless close() function which Releases the function from the main thread :S

during debugging I also found multiple occasions where mErrorCallback is assumed to be present which is not enforced! I added a few ifs() there.

I am pretty sure this is not a good fix. but everything else would probably involve api changes :S