### PR TITLE
Fix serialize-javascript CPU exhaustion vulnerability (GHSA-qj8w-gfj5-8c6v)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "mocha": "^10.6.0"
   },
   "resolutions": {
-    "serialize-javascript": "^7.0.3"
+    "serialize-javascript": "^7.0.5"
   },
   "keywords": [
     "FileWatcher",

--- a/yarn.lock
+++ b/yarn.lock
@@ -851,10 +851,10 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-serialize-javascript@^6.0.2, serialize-javascript@^7.0.3:
-  version "7.0.4"
-  resolved "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz#c517735bd5b7631dd1fc191ee19cbb713ff8e05c"
-  integrity sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==
+serialize-javascript@^6.0.2, serialize-javascript@^7.0.5:
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.5.tgz#c798cc0552ffbb08981914a42a8756e339d0d5b1"
+  integrity sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==
 
 shebang-command@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Summary
- Update `serialize-javascript` yarn resolution from `^7.0.3` to `^7.0.5` (7.0.4 → 7.0.5)
- Fixes Dependabot alert #47: CPU Exhaustion DoS via crafted array-like objects

## Test plan
- [x] All 27 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)