### PR TITLE
Fix picomatch method injection vulnerability (GHSA-3v7f-55p6-f55p)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "mocha": "^10.6.0"
   },
   "resolutions": {
-    "serialize-javascript": "^7.0.3"
+    "serialize-javascript": "^7.0.3",
+    "picomatch": "^2.3.2"
   },
   "keywords": [
     "FileWatcher",

--- a/yarn.lock
+++ b/yarn.lock
@@ -795,10 +795,10 @@ path-key@^3.1.0:
   resolved "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-picomatch@^2.0.4, picomatch@^2.2.1:
-  version "2.3.1"
-  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
## Summary
- Add yarn resolution for `picomatch` `^2.3.2` (2.3.1 → 2.3.2)
- Fixes Dependabot alert 43: Method Injection in POSIX Character Classes causes incorrect glob matching
- Transitive dependency via mocha → chokidar → anymatch/readdirp

## Test plan
- [x] All 27 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)