### PR TITLE
Fix flatted prototype pollution vulnerability (GHSA-rf6f-7fwh-wjgh)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   },
   "resolutions": {
     "serialize-javascript": "^7.0.5",
-    "picomatch": "^2.3.2"
+    "picomatch": "^2.3.2",
+    "flatted": "^3.4.2"
   },
   "keywords": [
     "FileWatcher",

--- a/yarn.lock
+++ b/yarn.lock
@@ -431,10 +431,10 @@ flat@^5.0.2:
   resolved "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
-flatted@^3.2.9:
-  version "3.3.1"
-  resolved "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz#21db470729a6734d4997002f439cb308987f567a"
-  integrity sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==
+flatted@^3.2.9, flatted@^3.4.2:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.2.tgz#f5c23c107f0f37de8dbdf24f13722b3b98d52726"
+  integrity sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==
 
 fs-extra@^11.2.0:
   version "11.2.0"


### PR DESCRIPTION
## Summary
- Add yarn resolution for `flatted` `^3.4.2` (3.3.1 → 3.4.2)
- Fixes Dependabot alert #41 (High): Prototype Pollution via `parse()` in flatted
- Transitive dependency via eslint → file-entry-cache → flat-cache

## Test plan
- [x] All 27 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)